### PR TITLE
installation: decrease minimum version of fs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup_requires = [
 ]
 
 install_requires = [
-    'fs>=2.0',
+    'fs>=0.5.4',
     'psycopg2-binary>=2.6.1'
     'SQLAlchemy>=1.2.7',
     'sqlalchemy-utils>=0.31.0',


### PR DESCRIPTION
* `fs>=2.0` has a conflict with current invenio-records-rest whose
  latest supported version of `fs` is <2.0.