### PR TITLE
models: addition of access times in job cache

### DIFF
--- a/reana_commons/models.py
+++ b/reana_commons/models.py
@@ -212,3 +212,4 @@ class JobCache(Base, Timestamp):
     parameters = Column(String(1024))
     result_path = Column(String(1024))
     workspace_hash = Column(String(1024))
+    access_times = Column(JSONType)


### PR DESCRIPTION
* ADD calculate_file_access_time() methods in utils to return dict
  of workspace files and their last access times.

* ADD clean job_spec by removing workflow workspace that is unique.

Signed-off-by: Dinos Kousidis <dinos.kousidis@cern.ch>