### PR TITLE
installation: removal of `fs` dependency

### DIFF
--- a/reana_commons/utils.py
+++ b/reana_commons/utils.py
@@ -26,7 +26,6 @@ import json
 import os
 
 import click
-import fs
 
 
 def click_table_printer(headers, _filter, data):

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,6 @@ setup_requires = [
 install_requires = [
     'checksumdir>=1.1.4,<1.2',
     'click>=6.7,<7.0',
-    'fs>=0.5.4,<2.2',
     'jsonschema>=2.6.0,<2.7',
     'pika>=0.12.0,<0.13',
 ]


### PR DESCRIPTION
* Removes `fs` dependency that is not used anymore. (closes #18)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>