### PR TITLE
installation: upgrade Click version

### DIFF
--- a/reana_commons/version.py
+++ b/reana_commons/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.4.0.dev20181015"
+__version__ = "0.4.0.dev20181016"

--- a/setup.py
+++ b/setup.py
@@ -51,8 +51,8 @@ setup_requires = [
 install_requires = [
     'bravado>=9.0.6,<10.2',
     'checksumdir>=1.1.4,<1.2',
-    'click>=6.7,<7.0',
-    'jsonschema>=2.6.0,<2.7',
+    'click>=7.0,<8.0',
+    'jsonschema[format]>=2.6.0,<2.7',
     'kombu>=4.2.0,<5.0',
 ]
 


### PR DESCRIPTION
* Upgrades Click since its new minimum version in `bravado` changed
  to `7.0`.

* Includes `jsonschema` extra dependency on `format` because if we
  pin it without the extra the dependency is overwritten and format
  is missing for `bravado-core`.