### PR TITLE
config: amend config

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -5,4 +5,5 @@ The list of contributors in alphabetical order:
 
 - `Diego Rodriguez <https://orcid.org/0000-0003-0649-2002>`_
 - `Dinos Kousidis <https://orcid.org/0000-0002-4914-4289>`_
+- `Rokas Maciulaitis <https://orcid.org/0000-0003-1064-6967>`_
 - `Tibor Simko <https://orcid.org/0000-0001-7202-5803>`_

--- a/reana_commons/config.py
+++ b/reana_commons/config.py
@@ -49,7 +49,7 @@ OPENAPI_SPECS = {
             port=os.getenv('WORKFLOW_CONTROLLER_SERVICE_PORT_HTTP', '5000')),
         'reana_workflow_controller.json'),
     'reana-server': (
-        os.getenv('REANA_SERVER_URL', None),
+        os.getenv('REANA_SERVER_URL', '0.0.0.0'),
         'reana_server.json'),
     'reana-job-controller': (
         'http://{address}:{port}'.format(


### PR DESCRIPTION
* Changing default reana_server_url value from None to valid url,
  because initialization of SwaggerClient with swagger_spec.api_url
  as None fails.

Signed-off-by: Rokas Maciulaitis <rokas.maciulaitis@cern.ch>
Co-authored-by: Diego Rodriguez <diego.rodriguez@cern.ch>