### PR TITLE
openapi: deleted in set_workflow_status enum

### DIFF
--- a/reana_commons/openapi_specifications/reana_workflow_controller.json
+++ b/reana_commons/openapi_specifications/reana_workflow_controller.json
@@ -535,6 +535,11 @@
           },
           {
             "description": "Required. New status.",
+            "enum": [
+              "start",
+              "stop",
+              "deleted"
+            ],
             "in": "query",
             "name": "status",
             "required": true,


### PR DESCRIPTION
* Adds 'deleted' as possible status for set_workflow_status view
  method.

Signed-off-by: Dinos Kousidis <dinos.kousidis@cern.ch>