### PR TITLE
consumer: workflow-submission queue

### DIFF
--- a/reana_commons/config.py
+++ b/reana_commons/config.py
@@ -33,11 +33,16 @@ MQ_DEFAULT_FORMAT = 'json'
 MQ_DEFAULT_EXCHANGE = ''
 """Message queue (RabbitMQ) exchange."""
 
-MQ_DEFAULT_QUEUE = 'jobs-status'
-"""Name of the queue where to publish/consume from."""
-
-MQ_DEFAULT_ROUTING_KEY = 'jobs-status'
-"""Message queue (RabbitMQ) routing key."""
+MQ_DEFAULT_QUEUES = {'jobs-status':
+                     {'routing_key': 'jobs-status',
+                      'exchange': MQ_DEFAULT_EXCHANGE,
+                      'durable': False},
+                     'workflow-submission':
+                     {'routing_key': 'workflow-submission',
+                      'exchange': MQ_DEFAULT_EXCHANGE,
+                      'durable': True}
+                    }
+"""Default message queues."""
 
 MQ_PRODUCER_MAX_RETRIES = 3
 """Max retries to send a message."""

--- a/reana_commons/config.py
+++ b/reana_commons/config.py
@@ -10,6 +10,7 @@
 
 import os
 
+
 MQ_URL = os.getenv('RABBIT_MQ_URL',
                    'message-broker.default.svc.cluster.local')
 """Message queue (RabbitMQ) server host name."""
@@ -41,7 +42,7 @@ MQ_DEFAULT_QUEUES = {'jobs-status':
                      {'routing_key': 'workflow-submission',
                       'exchange': MQ_DEFAULT_EXCHANGE,
                       'durable': True}
-                    }
+                     }
 """Default message queues."""
 
 MQ_PRODUCER_MAX_RETRIES = 3
@@ -63,3 +64,19 @@ OPENAPI_SPECS = {
         'reana_job_controller.json')
 }
 """REANA Workflow Controller address."""
+
+K8S_MINIMUM_CAPACITY_CPU = 1
+"""Minimum allocatable cpu capacity in cluster to start new workflows."""
+
+K8S_MINIMUM_CAPACITY_MEMORY = 1000000
+"""Minimum allocatable memory capacity in cluster to start new workflows."""
+
+K8S_MINIMUM_CAPACITY_PODS = 109
+"""Minimum allocatable pod capacity in cluster to start new workflows."""
+
+K8S_MAXIMUM_CONCURRENT_JOBS = 1
+"""Upper limit on concurrent jobs running in the cluster."""
+
+REANA_READY_CONDITIONS = {'reana_commons.tasks':
+                             ['check_predefined_conditions',
+                              'check_running_job_count']}

--- a/reana_commons/config.py
+++ b/reana_commons/config.py
@@ -10,7 +10,6 @@
 
 import os
 
-
 MQ_URL = os.getenv('RABBIT_MQ_URL',
                    'message-broker.default.svc.cluster.local')
 """Message queue (RabbitMQ) server host name."""
@@ -65,18 +64,9 @@ OPENAPI_SPECS = {
 }
 """REANA Workflow Controller address."""
 
-K8S_MINIMUM_CAPACITY_CPU = 1
-"""Minimum allocatable cpu capacity in cluster to start new workflows."""
-
-K8S_MINIMUM_CAPACITY_MEMORY = 1000000
-"""Minimum allocatable memory capacity in cluster to start new workflows."""
-
-K8S_MINIMUM_CAPACITY_PODS = 109
-"""Minimum allocatable pod capacity in cluster to start new workflows."""
-
-K8S_MAXIMUM_CONCURRENT_JOBS = 1
+K8S_MAXIMUM_CONCURRENT_JOBS = 10
 """Upper limit on concurrent jobs running in the cluster."""
 
 REANA_READY_CONDITIONS = {'reana_commons.tasks':
-                             ['check_predefined_conditions',
-                              'check_running_job_count']}
+                          ['check_predefined_conditions',
+                           'check_running_job_count']}

--- a/reana_commons/openapi_specifications/reana_server.json
+++ b/reana_commons/openapi_specifications/reana_server.json
@@ -675,6 +675,121 @@
         "summary": "Get parameters of a workflow."
       }
     },
+    "/api/workflows/{workflow_id_or_name}/start": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "This resource starts the workflow execution process. Resource is expecting a workflow UUID.",
+        "operationId": "start_workflow",
+        "parameters": [
+          {
+            "description": "Required. Analysis UUID or name.",
+            "in": "path",
+            "name": "workflow_id_or_name",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Required. The API access_token of workflow owner.",
+            "in": "query",
+            "name": "access_token",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Optional. Additional input parameters and operational options.",
+            "in": "body",
+            "name": "parameters",
+            "required": false,
+            "schema": {
+              "type": "object"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Request succeeded. Info about a workflow, including the execution status is returned.",
+            "examples": {
+              "application/json": {
+                "id": "256b25f4-4cfb-4684-b7a8-73872ef455a1",
+                "message": "Workflow submitted",
+                "status": "queued",
+                "user": "00000000-0000-0000-0000-000000000000",
+                "workflow_name": "mytest.1"
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string"
+                },
+                "user": {
+                  "type": "string"
+                },
+                "workflow_id": {
+                  "type": "string"
+                },
+                "workflow_name": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "400": {
+            "description": "Request failed. The incoming payload seems malformed.",
+            "examples": {
+              "application/json": {
+                "message": "Malformed request."
+              }
+            }
+          },
+          "403": {
+            "description": "Request failed. User is not allowed to access workflow.",
+            "examples": {
+              "application/json": {
+                "message": "User 00000000-0000-0000-0000-000000000000 is not allowed to access workflow 256b25f4-4cfb-4684-b7a8-73872ef455a1"
+              }
+            }
+          },
+          "404": {
+            "description": "Request failed. Either User or Workflow does not exist.",
+            "examples": {
+              "application/json": {
+                "message": "Workflow 256b25f4-4cfb-4684-b7a8-73872ef455a1 does not exist"
+              }
+            }
+          },
+          "409": {
+            "description": "Request failed. The workflow could not be started due to a conflict.",
+            "examples": {
+              "application/json": {
+                "message": "Workflow 256b25f4-4cfb-4684-b7a8-73872ef455a1 could not be started because it is already running."
+              }
+            }
+          },
+          "500": {
+            "description": "Request failed. Internal controller error."
+          },
+          "501": {
+            "description": "Request failed. The specified status change is not implemented.",
+            "examples": {
+              "application/json": {
+                "message": "Status resume is not supported yet."
+              }
+            }
+          }
+        },
+        "summary": "Start workflow."
+      }
+    },
     "/api/workflows/{workflow_id_or_name}/status": {
       "get": {
         "description": "This resource reports the status of a workflow. Resource is expecting a workflow UUID.",

--- a/reana_commons/publisher.py
+++ b/reana_commons/publisher.py
@@ -13,8 +13,7 @@ import logging
 from kombu import Connection, Exchange, Queue
 
 from .config import (MQ_CONNECTION_STRING, MQ_DEFAULT_EXCHANGE,
-                     MQ_DEFAULT_FORMAT, MQ_DEFAULT_QUEUES,
-                     MQ_PASS, MQ_PORT,
+                     MQ_DEFAULT_FORMAT, MQ_DEFAULT_QUEUES, MQ_PASS, MQ_PORT,
                      MQ_PRODUCER_MAX_RETRIES, MQ_URL, MQ_USER)
 
 

--- a/reana_commons/publisher.py
+++ b/reana_commons/publisher.py
@@ -86,13 +86,16 @@ class BasePublisher():
 class WorkflowStatusPublisher(BasePublisher):
     """Progress publisher to MQ."""
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         """Constructor."""
         queue = 'jobs-status'
-        super(WorkflowStatusPublisher, self).__init__(
-            queue,
-            MQ_DEFAULT_QUEUES[queue]['routing_key'],
-            durable=MQ_DEFAULT_QUEUES[queue]['durable'])
+        if 'queue' not in kwargs:
+            kwargs['queue'] = 'jobs-status'
+        if 'routing_key' not in kwargs:
+            kwargs['routing_key'] = MQ_DEFAULT_QUEUES[queue]['routing_key']
+        if 'durable' not in kwargs:
+            kwargs['durable'] = MQ_DEFAULT_QUEUES[queue]['durable']
+        super(WorkflowStatusPublisher, self).__init__(**kwargs)
 
     def publish_workflow_status(self, workflow_uuid, status,
                                 logs='', message=None):
@@ -118,13 +121,14 @@ class WorkflowStatusPublisher(BasePublisher):
 class WorkflowSubmissionPublisher(BasePublisher):
     """Workflow submission publisher."""
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         """Constructor."""
         queue = 'workflow-submission'
         super(WorkflowSubmissionPublisher, self).__init__(
             queue,
             MQ_DEFAULT_QUEUES[queue]['routing_key'],
-            durable=MQ_DEFAULT_QUEUES[queue]['durable'])
+            durable=MQ_DEFAULT_QUEUES[queue]['durable'],
+            **kwargs)
 
     def publish_workflow_submission(self,
                                     user_id,

--- a/reana_commons/tasks.py
+++ b/reana_commons/tasks.py
@@ -7,18 +7,15 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 """REANA common Celery tasks."""
 
-import logging
 import importlib
+import logging
 
 from celery import shared_task
 from celery.task.control import revoke
 from kubernetes.client.rest import ApiException
 
 from reana_commons.api_client import JobControllerAPIClient
-from reana_commons.config import (K8S_MINIMUM_CAPACITY_CPU,
-                                  K8S_MINIMUM_CAPACITY_MEMORY,
-                                  K8S_MINIMUM_CAPACITY_PODS,
-                                  K8S_MAXIMUM_CONCURRENT_JOBS)
+from reana_commons.config import K8S_MAXIMUM_CONCURRENT_JOBS
 from reana_commons.k8s.api_client import (current_k8s_batchv1_api_client,
                                           current_k8s_corev1_api_client)
 

--- a/reana_commons/tasks.py
+++ b/reana_commons/tasks.py
@@ -11,8 +11,10 @@ import logging
 
 from celery import shared_task
 from celery.task.control import revoke
+from kubernetes.client.rest import ApiException
 
 from reana_commons.api_client import JobControllerAPIClient
+from reana_commons.k8s.api_client import current_k8s_corev1_api_client
 
 log = logging.getLogger(__name__)
 
@@ -46,4 +48,10 @@ def stop_workflow(workflow_uuid, job_list):
 
 def reana_ready():
     """Check if reana can start new workflows."""
+    try:
+        import wdb
+        wdb.set_trace()
+        current_k8s_corev1_api_client.read_node_status('minikube')
+    except ApiException as e:
+        print(str(e))
     return True

--- a/reana_commons/tasks.py
+++ b/reana_commons/tasks.py
@@ -42,3 +42,8 @@ def stop_workflow(workflow_uuid, job_list):
             workflow_uuid
         ))
         log.error(e)
+
+
+def reana_ready():
+    """Check if reana can start new workflows."""
+    return True

--- a/reana_commons/tasks.py
+++ b/reana_commons/tasks.py
@@ -8,13 +8,19 @@
 """REANA common Celery tasks."""
 
 import logging
+import importlib
 
 from celery import shared_task
 from celery.task.control import revoke
 from kubernetes.client.rest import ApiException
 
 from reana_commons.api_client import JobControllerAPIClient
-from reana_commons.k8s.api_client import current_k8s_corev1_api_client
+from reana_commons.config import (K8S_MINIMUM_CAPACITY_CPU,
+                                  K8S_MINIMUM_CAPACITY_MEMORY,
+                                  K8S_MINIMUM_CAPACITY_PODS,
+                                  K8S_MAXIMUM_CONCURRENT_JOBS)
+from reana_commons.k8s.api_client import (current_k8s_batchv1_api_client,
+                                          current_k8s_corev1_api_client)
 
 log = logging.getLogger(__name__)
 
@@ -48,10 +54,43 @@ def stop_workflow(workflow_uuid, job_list):
 
 def reana_ready():
     """Check if reana can start new workflows."""
+    from reana_commons.config import REANA_READY_CONDITIONS
+    for module_name, condition_list in REANA_READY_CONDITIONS.items():
+        for condition_name in condition_list:
+            module = importlib.import_module(module_name)
+            condition_func = getattr(module, condition_name)
+            if not condition_func():
+                return False
+    return True
+
+
+def check_predefined_conditions():
+    """Check k8s predefined conditions for the nodes."""
     try:
-        import wdb
-        wdb.set_trace()
-        current_k8s_corev1_api_client.read_node_status('minikube')
+        node_info = current_k8s_corev1_api_client.list_node()
+        for node in node_info.items:
+            # check based on the predefined conditions about the
+            # node status: MemoryPressure, OutOfDisk, KubeletReady
+            #              DiskPressure, PIDPressure,
+            for condition in node.status.conditions:
+                if not condition.status:
+                    return False
     except ApiException as e:
-        print(str(e))
+        log.error('Something went wrong while getting node information.')
+        log.error(e)
+        return False
+    return True
+
+
+def check_running_job_count():
+    """Check upper limit on running jobs."""
+    try:
+        job_list = current_k8s_batchv1_api_client.\
+            list_job_for_all_namespaces()
+        if len(job_list.items) > K8S_MAXIMUM_CONCURRENT_JOBS:
+            return False
+    except ApiException as e:
+        log.error('Something went wrong while getting running job list.')
+        log.error(e)
+        return False
     return True

--- a/reana_commons/version.py
+++ b/reana_commons/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.5.0.dev20181213"
+__version__ = "0.5.0.dev20190116"

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ tests_require = [
     'pytest-cache>=1.0',
     'pytest-cov>=1.8.0',
     'pytest-pep8>=1.0.6',
-    'pytest-reana>=0.5.0.dev20181203',
+    'pytest-reana>=0.5.0.dev20190116',
     'pytest>=3.8'
 ]
 

--- a/tests/test_mq.py
+++ b/tests/test_mq.py
@@ -49,7 +49,8 @@ def test_consume_msg(ConsumerBaseOnMessageMock, in_memory_queue_connection,
 def test_server_unreachable(ConsumerBase, default_queue):
     """Test consumer never starts because server is unreachable."""
     unreachable_connection = Connection('amqp://unreachable:5672')
-    consumer = ConsumerBase(connection=unreachable_connection)
+    consumer = ConsumerBase(queue=default_queue,
+                            connection=unreachable_connection)
     with pytest.raises(OperationalError):
         # Typically we will leave by default the connection max retires since
         # the BaseConsumer takes care of recovering connection through
@@ -60,7 +61,8 @@ def test_server_unreachable(ConsumerBase, default_queue):
 
 
 def test_workflow_status_publish(ConsumerBaseOnMessageMock,
-                                 in_memory_queue_connection, default_queue,
+                                 in_memory_queue_connection,
+                                 default_queue,
                                  consume_queue):
     """Test WorkflowStatusPublisher."""
     consumer = ConsumerBaseOnMessageMock(

--- a/tests/test_mq.py
+++ b/tests/test_mq.py
@@ -38,7 +38,7 @@ def test_consume_msg(ConsumerBaseOnMessageMock, in_memory_queue_connection,
     """Test message is consumed from the queue."""
     consumer = ConsumerBaseOnMessageMock(
         connection=in_memory_queue_connection,
-        queues=[default_queue])
+        queue=default_queue)
     default_in_memory_producer.publish({'hello': 'REANA'},
                                        declare=[default_queue])
     consume_queue(consumer, limit=1)
@@ -65,7 +65,7 @@ def test_workflow_status_publish(ConsumerBaseOnMessageMock,
     """Test WorkflowStatusPublisher."""
     consumer = ConsumerBaseOnMessageMock(
         connection=in_memory_queue_connection,
-        queues=[default_queue])
+        queue=default_queue)
     workflow_status_publisher = WorkflowStatusPublisher(
         connection=in_memory_queue_connection,
         routing_key=default_queue.routing_key,

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2018 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 2 of the License, or (at your option) any later
+# version.
+#
+# REANA is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with REANA; if not, see <http://www.gnu.org/licenses>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization or
+# submit itself to any jurisdiction.
+
+"""REANA-Commons Task tests."""
+
+from mock import patch
+
+from reana_commons.tasks import reana_ready
+
+
+def test_reana_ready():
+    """Test that reana_ready task checks all conditions."""
+    with patch('reana_commons.config.REANA_READY_CONDITIONS',
+               {'pytest_reana.fixtures':
+                ['sample_condition_for_starting_queued_workflows',
+                 'sample_condition_for_starting_queued_workflows',
+                 'sample_condition_for_requeueing_workflows']}):
+        assert not reana_ready()
+
+    with patch('reana_commons.config.REANA_READY_CONDITIONS',
+               {'pytest_reana.fixtures':
+                ['sample_condition_for_starting_queued_workflows']}):
+        assert reana_ready()


### PR DESCRIPTION
* Adds workflow-submission queue to default queues.
  Refactors configuration to allow for multiple default queues,
  linked with their parameters.

Connects https://github.com/reanahub/reana/issues/119
Depends on https://github.com/reanahub/pytest-reana/pull/36

Signed-off-by: Dinos Kousidis <dinos.kousidis@cern.ch>