### PR TITLE
config: CVMFS repositories

### DIFF
--- a/reana_commons/api_client.py
+++ b/reana_commons/api_client.py
@@ -67,7 +67,7 @@ class JobControllerAPIClient(BaseAPIClient):
                prettified_cmd='',
                workflow_workspace='',
                job_name='',
-               cvmfs_mounts=None):
+               cvmfs_mounts=False):
         """Submit a job to RJC API.
 
         :param name: Name of the job.
@@ -76,6 +76,8 @@ class JobControllerAPIClient(BaseAPIClient):
         :param cmd: String which represents the command to execute. It can be
             modified by the workflow engine i.e. prepending ``cd /some/dir/``.
         :prettified_cmd: Original command submitted by the user.
+        :workflow_workspace: Path to the workspace of the workflow.
+        :cvmfs_mounts: Boolean flag to mount CVMFS volumes in job pods.
         :return: Returns a dict with the ``job_id``.
         """
         job_spec = {

--- a/reana_commons/config.py
+++ b/reana_commons/config.py
@@ -81,3 +81,27 @@ REANA_ENGINE_LOG_FORMAT = os.getenv('ENGINE_LOG_FORMAT',
                                     '%(levelname)s - '
                                     '%(message)s')
 """Format of engine logs."""
+
+CVMFS_REPOSITORIES = {
+    'alice.cern.ch': 'alice',
+    'alice-ocdb.cern.ch': 'alice-ocdb',
+    'ams.cern.ch': 'ams',
+    'atlas.cern.ch': 'atlas',
+    'atlas-condb.cern.ch': 'atlas-condb',
+    'atlas-nightlies.cern.ch': 'atlas-nightlies',
+    'cms.cern.ch': 'cms',
+    'cms-ib.cern.ch': 'cms-ib',
+    'compass.cern.ch': 'compass',
+    'compass-condb.cern.ch': 'compass-condb',
+    'cvmfs-config.cern.ch': 'cvmfs-config',
+    'fcc.cern.ch': 'fcc',
+    'geant4.cern.ch': 'geant4',
+    'ilc.desy.de': 'ilc-desy',
+    'lhcb.cern.ch': 'lhcb',
+    'lhcb-condb.cern.ch': 'lhcb-condb',
+    'na61.cern.ch': 'na61',
+    'na62.cern.ch': 'na62',
+    'projects.cern.ch': 'projects',
+    'sft.cern.ch': 'sft'
+}
+"""CVMFS repositories available for mounting."""

--- a/reana_commons/openapi_specifications/reana_job_controller.json
+++ b/reana_commons/openapi_specifications/reana_job_controller.json
@@ -6,10 +6,8 @@
           "type": "string"
         },
         "cvmfs_mounts": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
+          "default": "",
+          "type": "string"
         },
         "docker_img": {
           "type": "string"
@@ -34,7 +32,6 @@
       },
       "required": [
         "cmd",
-        "cvmfs_mounts",
         "docker_img",
         "experiment",
         "job_id",
@@ -51,11 +48,8 @@
           "type": "string"
         },
         "cvmfs_mounts": {
-          "default": [],
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
+          "default": "",
+          "type": "string"
         },
         "docker_img": {
           "type": "string"
@@ -168,8 +162,8 @@
                   "1612a779-f3fa-4344-8819-3d12fa9b9d90": {
                     "cmd": "date",
                     "cvmfs_mounts": [
-                      "atlas-condb",
-                      "atlas"
+                      "atlas.cern.ch",
+                      "atlas-condb.cern.ch"
                     ],
                     "docker_img": "busybox",
                     "experiment": "atlas",
@@ -181,8 +175,8 @@
                   "2e4bbc1d-db5e-4ee0-9701-6e2b1ba55c20": {
                     "cmd": "date",
                     "cvmfs_mounts": [
-                      "atlas-condb",
-                      "atlas"
+                      "atlas.cern.ch",
+                      "atlas-condb.cern.ch"
                     ],
                     "docker_img": "busybox",
                     "experiment": "atlas",
@@ -275,8 +269,8 @@
                 "job": {
                   "cmd": "date",
                   "cvmfs_mounts": [
-                    "atlas-condb",
-                    "atlas"
+                    "atlas.cern.ch",
+                    "atlas-condb.cern.ch"
                   ],
                   "docker_img": "busybox",
                   "experiment": "atlas",


### PR DESCRIPTION
* Adds dict with available CVMFS repositories in config.py,
  which can be mounted in job pods.

* Updates openapi specs for job-controller, changing the
  cvmfs_mounts parameter to boolean. If True, all CVMFS repos are
  mounted.

Connect https://github.com/reanahub/reana-cluster/issues/154

Signed-off-by: Dinos Kousidis <dinos.kousidis@cern.ch>