### PR TITLE
api_client: cvmfs_mounts default value fix

### DIFF
--- a/reana_commons/api_client.py
+++ b/reana_commons/api_client.py
@@ -67,7 +67,7 @@ class JobControllerAPIClient(BaseAPIClient):
                prettified_cmd='',
                workflow_workspace='',
                job_name='',
-               cvmfs_mounts=False):
+               cvmfs_mounts='false'):
         """Submit a job to RJC API.
 
         :param name: Name of the job.
@@ -77,7 +77,7 @@ class JobControllerAPIClient(BaseAPIClient):
             modified by the workflow engine i.e. prepending ``cd /some/dir/``.
         :prettified_cmd: Original command submitted by the user.
         :workflow_workspace: Path to the workspace of the workflow.
-        :cvmfs_mounts: Boolean flag to mount CVMFS volumes in job pods.
+        :cvmfs_mounts: String with CVMFS volumes to mount in job pods.
         :return: Returns a dict with the ``job_id``.
         """
         job_spec = {

--- a/reana_commons/openapi_specifications/reana_job_controller.json
+++ b/reana_commons/openapi_specifications/reana_job_controller.json
@@ -161,10 +161,7 @@
                 "jobs": {
                   "1612a779-f3fa-4344-8819-3d12fa9b9d90": {
                     "cmd": "date",
-                    "cvmfs_mounts": [
-                      "atlas.cern.ch",
-                      "atlas-condb.cern.ch"
-                    ],
+                    "cvmfs_mounts": "[\"atlas.cern.ch\", \"atlas-condb.cern.ch\"]",
                     "docker_img": "busybox",
                     "experiment": "atlas",
                     "job_id": "1612a779-f3fa-4344-8819-3d12fa9b9d90",
@@ -174,10 +171,7 @@
                   },
                   "2e4bbc1d-db5e-4ee0-9701-6e2b1ba55c20": {
                     "cmd": "date",
-                    "cvmfs_mounts": [
-                      "atlas.cern.ch",
-                      "atlas-condb.cern.ch"
-                    ],
+                    "cvmfs_mounts": "[\"atlas.cern.ch\", \"atlas-condb.cern.ch\"]",
                     "docker_img": "busybox",
                     "experiment": "atlas",
                     "job_id": "2e4bbc1d-db5e-4ee0-9701-6e2b1ba55c20",
@@ -268,10 +262,7 @@
               "application/json": {
                 "job": {
                   "cmd": "date",
-                  "cvmfs_mounts": [
-                    "atlas.cern.ch",
-                    "atlas-condb.cern.ch"
-                  ],
+                  "cvmfs_mounts": "[\"atlas.cern.ch\", \"atlas-condb.cern.ch\"]",
                   "docker_img": "busybox",
                   "experiment": "atlas",
                   "job_id": "cdcf48b1-c2f3-4693-8230-b066e088c6ac",

--- a/reana_commons/version.py
+++ b/reana_commons/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.5.0.dev20190212"
+__version__ = "0.5.0.dev20190213"


### PR DESCRIPTION
* Fixes default value for `cvmfs_mounts` in api_client.py.

* Fixes example for `cvmfs_mounts` in r-server openapi spec.

Connect https://github.com/reanahub/reana-cluster/issues/154

Signed-off-by: Dinos Kousidis <dinos.kousidis@cern.ch>