### PR TITLE
global: pvc and sc templates, storagev1api client

### DIFF
--- a/reana_commons/config.py
+++ b/reana_commons/config.py
@@ -105,3 +105,22 @@ CVMFS_REPOSITORIES = {
     'sft.cern.ch': 'sft'
 }
 """CVMFS repositories available for mounting."""
+
+REANA_CVMFS_PVC_TEMPLATE = {
+    "metadata":
+        {"name": ""},
+    "spec":
+        {"accessModes": ["ReadOnlyMany"],
+         "storageClassName": "",
+         "resources": {"requests": {"storage": "1G"}}}
+}
+"""CVMFS persistent volume claim template."""
+
+REANA_CVMFS_SC_TEMPLATE = {
+    "metadata":
+        {"name": ""},
+    "provisioner": "csi-cvmfsplugin",
+    "parameters":
+        {"repository": ""}
+}
+"""CVMFS storage claim template."""

--- a/reana_commons/k8s/api_client.py
+++ b/reana_commons/k8s/api_client.py
@@ -29,6 +29,8 @@ def create_api_client(api='BatchV1'):
         api_client = client.ExtensionsV1beta1Api()
     elif api == 'CoreV1':
         api_client = client.CoreV1Api()
+    elif api == 'StorageV1':
+        api_client = client.StorageV1Api()
     else:
         api_client = client.BatchV1Api()
     return api_client
@@ -39,3 +41,5 @@ current_k8s_corev1_api_client = LocalProxy(partial(create_api_client,
                                                    api='CoreV1'))
 current_k8s_extensions_v1beta1 = LocalProxy(partial(create_api_client,
                                                     api='extensions/v1beta1'))
+current_k8s_storagev1_api_client = LocalProxy(partial(create_api_client,
+                                                      api='StorageV1'))

--- a/reana_commons/utils.py
+++ b/reana_commons/utils.py
@@ -227,8 +227,8 @@ def create_cvmfs_storage_class(cvmfs_volume):
                 render_cvmfs_sc(cvmfs_volume)
             )
     except ApiException as e:
-        if e.status == 409:
-            pass
+        if e.status != 409:
+            raise e
 
 
 def create_cvmfs_persistent_volume_claim(cvmfs_volume):
@@ -240,5 +240,5 @@ def create_cvmfs_persistent_volume_claim(cvmfs_volume):
                 render_cvmfs_pvc(cvmfs_volume)
             )
     except ApiException as e:
-        if e.status == 409:
-            pass
+        if e.status != 409:
+            raise e

--- a/reana_commons/version.py
+++ b/reana_commons/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.5.0.dev20190215"
+__version__ = "0.5.0.dev20190218"


### PR DESCRIPTION
* Adds templates in config.py for creating CVMFS persistent volume
  claims and storage classes. The templates take the CVMFS volume
  as parameter and can be rendered by the utility methods added in
  utils.py.

* Adds StorageV1Api kubernetes client for operating on storage
  resources.

Connect https://github.com/reanahub/reana-cluster/issues/154

Signed-off-by: Dinos Kousidis <dinos.kousidis@cern.ch>