### PR TITLE
openapi: update RJC openapi spec

### DIFF
--- a/reana_commons/openapi_specifications/reana_job_controller.json
+++ b/reana_commons/openapi_specifications/reana_job_controller.json
@@ -78,12 +78,16 @@
         "shared_file_system": {
           "default": true,
           "type": "boolean"
+        },
+        "workflow_workspace": {
+          "type": "string"
         }
       },
       "required": [
         "docker_img",
         "experiment",
-        "job_name"
+        "job_name",
+        "workflow_workspace"
       ],
       "type": "object"
     }
@@ -161,7 +165,10 @@
                 "jobs": {
                   "1612a779-f3fa-4344-8819-3d12fa9b9d90": {
                     "cmd": "date",
-                    "cvmfs_mounts": "[\"atlas.cern.ch\", \"atlas-condb.cern.ch\"]",
+                    "cvmfs_mounts": [
+                      "atlas.cern.ch",
+                      "atlas-condb.cern.ch"
+                    ],
                     "docker_img": "busybox",
                     "experiment": "atlas",
                     "job_id": "1612a779-f3fa-4344-8819-3d12fa9b9d90",
@@ -171,7 +178,10 @@
                   },
                   "2e4bbc1d-db5e-4ee0-9701-6e2b1ba55c20": {
                     "cmd": "date",
-                    "cvmfs_mounts": "[\"atlas.cern.ch\", \"atlas-condb.cern.ch\"]",
+                    "cvmfs_mounts": [
+                      "atlas.cern.ch",
+                      "atlas-condb.cern.ch"
+                    ],
                     "docker_img": "busybox",
                     "experiment": "atlas",
                     "job_id": "2e4bbc1d-db5e-4ee0-9701-6e2b1ba55c20",
@@ -262,7 +272,10 @@
               "application/json": {
                 "job": {
                   "cmd": "date",
-                  "cvmfs_mounts": "[\"atlas.cern.ch\", \"atlas-condb.cern.ch\"]",
+                  "cvmfs_mounts": [
+                    "atlas.cern.ch",
+                    "atlas-condb.cern.ch"
+                  ],
                   "docker_img": "busybox",
                   "experiment": "atlas",
                   "job_id": "cdcf48b1-c2f3-4693-8230-b066e088c6ac",


### PR DESCRIPTION
* Includes workflow_workspace as payload so RJC can determine the
  relative path of the workflow workspace to mount on jobs.