### PR TITLE
config: add k8s default namespace

### DIFF
--- a/reana_commons/api_client.py
+++ b/reana_commons/api_client.py
@@ -61,6 +61,7 @@ class JobControllerAPIClient(BaseAPIClient):
     """REANA-Job-Controller http client class."""
 
     def submit(self,
+               workflow_uuid='',
                experiment='',
                image='',
                cmd='',
@@ -88,7 +89,8 @@ class JobControllerAPIClient(BaseAPIClient):
             'env_vars': {},
             'workflow_workspace': workflow_workspace,
             'job_name': job_name,
-            'cvmfs_mounts': cvmfs_mounts
+            'cvmfs_mounts': cvmfs_mounts,
+            'workflow_uuid': workflow_uuid
         }
 
         response, http_response = self._client.jobs.create_job(job=job_spec).\

--- a/reana_commons/config.py
+++ b/reana_commons/config.py
@@ -133,3 +133,6 @@ REANA_STORAGE_BACKEND = os.getenv('REANA_STORAGE_BACKEND', 'LOCAL')
 
 REANA_WORKFLOW_UMASK = 0o0002
 """Umask used for workflow worksapce."""
+
+K8S_DEFAULT_NAMESPACE = "default"
+"""Kubernetes workflow runtime default namespace"""

--- a/reana_commons/openapi_specifications/reana_job_controller.json
+++ b/reana_commons/openapi_specifications/reana_job_controller.json
@@ -43,6 +43,9 @@
     },
     "JobRequest": {
       "properties": {
+        "backend": {
+          "type": "string"
+        },
         "cmd": {
           "default": "",
           "type": "string"
@@ -68,9 +71,6 @@
         "job_name": {
           "type": "string"
         },
-        "job_type": {
-          "type": "string"
-        },
         "prettified_cmd": {
           "default": "",
           "type": "string"
@@ -78,6 +78,9 @@
         "shared_file_system": {
           "default": true,
           "type": "boolean"
+        },
+        "workflow_uuid": {
+          "type": "string"
         },
         "workflow_workspace": {
           "type": "string"
@@ -87,6 +90,7 @@
         "docker_img",
         "experiment",
         "job_name",
+        "workflow_uuid",
         "workflow_workspace"
       ],
       "type": "object"


### PR DESCRIPTION
config+api: add k8s default namespace & multiple job backends support

* Add config var for default K8s job namesapce. API changes for multiple
   job bakend support.
  Connects reanahub/reana-job-controller/issues/118

Signed-off-by: Rokas Maciulaitis <rokas.maciulaitis@cern.ch>