### PR TITLE
api-client: verify SSL certificates off by default

### DIFF
--- a/reana_commons/api_client.py
+++ b/reana_commons/api_client.py
@@ -11,7 +11,7 @@ import json
 import os
 
 import pkg_resources
-from bravado.client import SwaggerClient
+from bravado.client import RequestsClient, SwaggerClient
 from bravado.exception import (HTTPBadRequest, HTTPInternalServerError,
                                HTTPNotFound)
 
@@ -29,7 +29,7 @@ class BaseAPIClient(object):
         json_spec = self._get_spec(spec_file)
         self._client = SwaggerClient.from_spec(
             json_spec,
-            http_client=http_client,
+            http_client=RequestsClient(ssl_verify=False),
             config={'also_return_response': True})
         if server_url is None:
             raise MissingAPIClientConfiguration(

--- a/reana_commons/version.py
+++ b/reana_commons/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.5.0.dev20190402"
+__version__ = "0.5.0.dev20190405"

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup_requires = [
 ]
 
 install_requires = [
-    'bravado>=9.0.6,<10.2',
+    'bravado>=10.2,<10.4',
     'celery>=4.1.0,<4.3',
     'checksumdir>=1.1.4,<1.2',
     'click>=7.0,<8.0',


### PR DESCRIPTION
* Since we are enforcing HTTPS through self-signed certificates to
  to access the REANA cluster we skip this verification for now
  (closes reanahub/reana-cluster#174).