### PR TITLE
config: setting default reana-server url

### DIFF
--- a/reana_commons/config.py
+++ b/reana_commons/config.py
@@ -55,7 +55,7 @@ OPENAPI_SPECS = {
             port=os.getenv('WORKFLOW_CONTROLLER_SERVICE_PORT_HTTP', '5000')),
         'reana_workflow_controller.json'),
     'reana-server': (
-        os.getenv('REANA_SERVER_URL'),
+        os.getenv('REANA_SERVER_URL', 'http://0.0.0.0:80'),
         'reana_server.json'),
     'reana-job-controller': (
         'http://{address}:{port}'.format(

--- a/reana_commons/version.py
+++ b/reana_commons/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.5.0.dev20190405"
+__version__ = "0.5.0.dev20190406"


### PR DESCRIPTION
* Setting default reana-server url for tests.
  Connects reanahub/reana-client/issues/252

Signed-off-by: Rokas Maciulaitis <rokas.maciulaitis@cern.ch>