### PR TITLE
k8s: fix storage backend detection

### DIFF
--- a/reana_commons/config.py
+++ b/reana_commons/config.py
@@ -126,8 +126,8 @@ REANA_CVMFS_SC_TEMPLATE = {
 INTERACTIVE_SESSION_TYPES = ['jupyter']
 """List of supported interactive systems."""
 
-REANA_STORAGE_BACKEND = os.getenv('REANA_STORAGE_BACKEND', 'LOCAL')
-"""Storage backend deployed in current REANA cluster."""
+REANA_STORAGE_BACKEND = os.getenv('REANA_STORAGE_BACKEND', 'local')
+"""Storage backend deployed in current REANA cluster ['local'|'cephfs']."""
 
 REANA_WORKFLOW_UMASK = 0o0002
 """Umask used for workflow worksapce."""

--- a/reana_commons/k8s/volumes.py
+++ b/reana_commons/k8s/volumes.py
@@ -79,7 +79,7 @@ def get_shared_volume(workflow_workspace, shared_volume_root):
         "mountPath": mount_path,
         "subPath": workflow_workspace_relative_to_owner}
 
-    if REANA_STORAGE_BACKEND == "CEPHFS":
+    if REANA_STORAGE_BACKEND == "cephfs":
         volume = get_k8s_cephfs_volume()
     else:
         volume = get_k8s_hostpath_volume(shared_volume_root)

--- a/reana_commons/version.py
+++ b/reana_commons/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.6.0.dev20190715"
+__version__ = "0.6.0.dev20190808"


### PR DESCRIPTION
* Storage backend types are lowercase strings, this caused interactive
  sessions to not get the correct storage type, which in production means
  interactive sessions get hostPath/local storage backend when it should
  be CephFS.