### PR TITLE
installation: remove usage of Celery

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,6 @@ Features
 - common API clients for internal communication
 - centralised OpenAPI specifications for REANA components
 - AMQP connection management and communication
-- common Celery tasks
 - utility functions for cluster components
 
 Useful links

--- a/reana_commons/tasks.py
+++ b/reana_commons/tasks.py
@@ -5,15 +5,13 @@
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
-"""REANA common Celery tasks."""
+"""REANA common tasks."""
 
 import importlib
 import logging
 
-from celery import shared_task
 from kubernetes.client.rest import ApiException
 
-from reana_commons.api_client import JobControllerAPIClient
 from reana_commons.config import K8S_MAXIMUM_CONCURRENT_JOBS
 from reana_commons.k8s.api_client import (current_k8s_batchv1_api_client,
                                           current_k8s_corev1_api_client)

--- a/reana_commons/version.py
+++ b/reana_commons/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.6.0.dev20190809"
+__version__ = "0.6.0.dev20190812"

--- a/setup.py
+++ b/setup.py
@@ -45,11 +45,10 @@ setup_requires = [
 
 install_requires = [
     'bravado>=10.2,<10.4',
-    'celery>=4.1.0,<4.3',
     'checksumdir>=1.1.4,<1.2',
     'click>=7.0',
     'jsonschema[format]>=2.6.0',
-    'kombu>=4.2.0,<4.4',
+    'kombu>=4.6,<4.7',
     'Werkzeug>=0.14.1',
 ]
 


### PR DESCRIPTION
* Removes usage of Celery in REANA, since serverless workflows Celery
  is not used (closes reanahub/reana#188).

* Upgrades `kombu` version since once we merge Invenio branch into
  REANA-Server master, the Celery version which Invenio requires,
  requires itself bigger `kombu` version.