### PR TITLE
global: fix bravado instantiation

### DIFF
--- a/reana_commons/version.py
+++ b/reana_commons/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.7.0.dev20200316"
+__version__ = "0.7.0.dev20200319"


### PR DESCRIPTION
After https://github.com/reanahub/reana-commons/commit/068b5a693d6325da0729babea551aa16981cf912, the bravado client only instantiates once. This is perfectly fine when running the cluster under normal conditions (development or production), however when we want to patch some endpoints to mock their response in the tests, the instantiation (`make_mock_api_client()`) only happens [once](https://github.com/reanahub/pytest-reana/blob/master/pytest_reana/test_utils.py#L27), thus preventing the patch itself and making tests to fail. This happens in all the modules that install `reana-commons`: `reana-client`, `reana-server`, `reana-workflow-controller`, etc.

This PR fixes this problem and only re-instantiates the bravado client under some specific conditions that shouldn't affect at all the optimizations introduced. These are explained in the code comment.