### PR TITLE
Grid proxy

### DIFF
--- a/reana_commons/api_client.py
+++ b/reana_commons/api_client.py
@@ -85,7 +85,8 @@ class JobControllerAPIClient(BaseAPIClient):
                compute_backend=None,
                kerberos=False,
                kubernetes_uid=None,
-               unpacked_img=False):
+               unpacked_img=False,
+               voms_proxy=False):
         """Submit a job to RJC API.
 
         :param job_name: Name of the job.
@@ -98,6 +99,8 @@ class JobControllerAPIClient(BaseAPIClient):
         :cvmfs_mounts: String with CVMFS volumes to mount in job pods.
         :compute_backend: Job compute backend.
         :kerberos: Decides if kerberos should be provided for job container.
+        :voms_proxy: Decides if grid proxy should be provided for job
+            container.
         :kubernetes_uid: Overwrites the default user id in the job container.
         :unpacked_img: Decides if unpacked iamges should be used.
         :return: Returns a dict with the ``job_id``.
@@ -118,6 +121,9 @@ class JobControllerAPIClient(BaseAPIClient):
 
         if kerberos:
             job_spec['kerberos'] = kerberos
+
+        if voms_proxy:
+            job_spec['voms_proxy'] = voms_proxy
 
         if kubernetes_uid:
             job_spec['kubernetes_uid'] = kubernetes_uid

--- a/reana_commons/k8s/secrets.py
+++ b/reana_commons/k8s/secrets.py
@@ -209,7 +209,7 @@ class REANAUserSecretsStore(object):
             'name': user_id,
             'secret': {
                 'secretName': user_id,
-                'items': self.get_file_secrets_as_k8s_specs()
+                'items': self.get_file_secrets_as_k8s_specs(),
             }
         }
 

--- a/reana_commons/openapi_specifications/reana_job_controller.json
+++ b/reana_commons/openapi_specifications/reana_job_controller.json
@@ -78,6 +78,9 @@
         "unpacked_img": {
           "type": "boolean"
         },
+        "voms_proxy": {
+          "type": "boolean"
+        },
         "workflow_uuid": {
           "type": "string"
         },

--- a/reana_commons/serial.py
+++ b/reana_commons/serial.py
@@ -59,6 +59,11 @@ serial_workflow_schema = {
                         "type": "integer",
                         "default": "None",
                     },
+                    "voms_proxy": {
+                        "$id": "#/properties/steps/properties/voms_proxy",
+                        "type": "boolean",
+                        "default": "false",
+                    },
                     "commands": {
                         "$id": "#/properties/steps/properties/commands",
                         "type": "array",


### PR DESCRIPTION
Add grid proxy schema to serial workflow. Proxy certificate is added when user specifies `proxy: true` in reana.yaml.

closes reanahub/reana#256