### PR TITLE
serial: add kubernetes_uid field

### DIFF
--- a/reana_commons/serial.py
+++ b/reana_commons/serial.py
@@ -54,6 +54,11 @@ serial_workflow_schema = {
                         "type": "boolean",
                         "default": "false",
                     },
+                    "kubernetes_uid": {
+                        "$id": "#/properties/steps/properties/kubernetes_uid",
+                        "type": "integer",
+                        "default": "None",
+                    },
                     "commands": {
                         "$id": "#/properties/steps/properties/commands",
                         "type": "array",


### PR DESCRIPTION
Add kubernetes_uid field to serial workflow to allow user to specify the Kubernetes runtime user ID

closes reanahub/reana-workflow-engine-serial#106