### PR TITLE
installation: addition of mock

### DIFF
--- a/reana_commons/version.py
+++ b/reana_commons/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.7.0.dev20200408"
+__version__ = "0.7.0.dev20200417"

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ install_requires = [
     'click>=7.0',
     'jsonschema[format]>=3.0.1',
     'kombu>=4.6,<4.7',
+    'mock>=3.0',
     'Werkzeug>=0.14.1',
 ]
 


### PR DESCRIPTION
REANA-Commons uses `mock` in `api_client` therefore we need to include
it in installation dependencies.

Fixes problem of installing naked `reana-client` package without any
test libraries.

Signed-off-by: Tibor Šimko <tibor.simko@cern.ch>