### PR TITLE
mail: use authentication only if production

### DIFF
--- a/reana_commons/email.py
+++ b/reana_commons/email.py
@@ -24,14 +24,14 @@ def send_email(receiver_email, subject, body, login_email=REANA_EMAIL_LOGIN,
                sender_email=REANA_EMAIL_SENDER):
     """Send emails from REANA platform."""
     message = 'Subject: {subject}\n\n{body}'.format(subject=subject, body=body)
-    if os.getenv('FLASK_ENV') == 'development':
+
+    context = ssl.create_default_context()
+    with smtplib.SMTP(REANA_EMAIL_SMTP_SERVER,
+                      REANA_EMAIL_SMTP_PORT) as server:
+        if os.getenv('FLASK_ENV') != 'development':
+            server.starttls(context=context)
+            server.login(login_email, REANA_EMAIL_PASSWORD)
+        server.sendmail(sender_email, receiver_email, message)
         logging.info('Email sent, login: {}, sender: {}, receiver: {}'
                      .format(login_email, sender_email, receiver_email))
         logging.info('Body:\n{}'.format(message))
-    else:
-        context = ssl.create_default_context()
-        with smtplib.SMTP(REANA_EMAIL_SMTP_SERVER,
-                          REANA_EMAIL_SMTP_PORT) as server:
-            server.starttls(context=context)
-            server.login(login_email, REANA_EMAIL_PASSWORD)
-            server.sendmail(sender_email, receiver_email, message)

--- a/reana_commons/version.py
+++ b/reana_commons/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.7.0.dev20200429"
+__version__ = "0.7.0.dev20200520"


### PR DESCRIPTION
* Allows testing email notifications workflow locally
  (addresses reanahub/reana#308).

(Adding closes here so it appears in kanban board)
Closes reanahub/reana#308