### PR TITLE
config: centrally configured k8s namespace

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Version master (UNRELEASED)
 - Centralises CephFS PVC name.
 - Updates to latest CVMFS CSI driver.
 - Introduces new configuration variable ``REANA_INFRASTRUCTURE_KUBERNETES_NAMESPACE`` to define the Kubernetes namespace in which REANA infrastructure components run.
+- Introduces new configuration variable ``REANA_RUNTIME_KUBERNETES_NAMESPACE`` to define the Kubernetes namespace in which REANA runtime components components run.
 - Increases default log level to ``INFO``.
 - Add Black formatter support.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Version master (UNRELEASED)
 - Upgrades minimum version of Kubernetes Python library to 11.
 - Centralises CephFS PVC name.
 - Updates to latest CVMFS CSI driver.
+- Introduces new configuration variable ``REANA_INFRASTRUCTURE_KUBERNETES_NAMESPACE`` to define the Kubernetes namespace in which REANA infrastructure components run.
 - Increases default log level to ``INFO``.
 - Add Black formatter support.
 

--- a/reana_commons/config.py
+++ b/reana_commons/config.py
@@ -49,6 +49,9 @@ It is a Python format string which take as arguments:
 - ``id``: unique identifier for the component, by default UUID4.
 """
 
+REANA_KUBERNETES_NAMESPACE = os.getenv("REANA_KUBERNETES_NAMESPACE", "default")
+"""Kubernetes namespace in which REANA is currectly deployed."""
+
 MQ_HOST = os.getenv(
     "RABBIT_MQ_HOST", "{}-message-broker".format(REANA_COMPONENT_PREFIX)
 )
@@ -198,9 +201,6 @@ REANA_SHARED_PVC_NAME = os.getenv(
 
 REANA_WORKFLOW_UMASK = 0o0002
 """Umask used for workflow worksapce."""
-
-K8S_DEFAULT_NAMESPACE = "default"
-"""Kubernetes workflow runtime default namespace"""
 
 WORKFLOW_RUNTIME_USER_NAME = os.getenv("WORKFLOW_RUNTIME_USER_NAME", "reana")
 """Default OS user name for running job controller."""

--- a/reana_commons/k8s/secrets.py
+++ b/reana_commons/k8s/secrets.py
@@ -15,7 +15,7 @@ from kubernetes import client
 from kubernetes.client.rest import ApiException
 from reana_commons.config import (
     REANA_COMPONENT_PREFIX,
-    REANA_KUBERNETES_NAMESPACE,
+    REANA_RUNTIME_KUBERNETES_NAMESPACE,
     REANA_USER_SECRET_MOUNT_PATH,
 )
 from reana_commons.errors import REANASecretAlreadyExists, REANASecretDoesNotExist
@@ -41,13 +41,13 @@ class REANAUserSecretsStore(object):
                 api_version="v1",
                 metadata=client.V1ObjectMeta(
                     name=str(self.user_secret_store_id),
-                    namespace=REANA_KUBERNETES_NAMESPACE,
+                    namespace=REANA_RUNTIME_KUBERNETES_NAMESPACE,
                 ),
                 data={},
             )
             empty_k8s_secret.metadata.annotations = {"secrets_types": "{}"}
             current_k8s_corev1_api_client.create_namespaced_secret(
-                REANA_KUBERNETES_NAMESPACE, empty_k8s_secret
+                REANA_RUNTIME_KUBERNETES_NAMESPACE, empty_k8s_secret
             )
             return empty_k8s_secret
         except ApiException as api_e:
@@ -66,14 +66,16 @@ class REANAUserSecretsStore(object):
                                  version of the store.
         """
         current_k8s_corev1_api_client.replace_namespaced_secret(
-            str(self.user_secret_store_id), REANA_KUBERNETES_NAMESPACE, k8s_user_secrets
+            str(self.user_secret_store_id),
+            REANA_RUNTIME_KUBERNETES_NAMESPACE,
+            k8s_user_secrets,
         )
 
     def _get_k8s_user_secrets_store(self):
         """Retrieve the Kubernetes secret which contains all user secrets."""
         try:
             k8s_user_secrets_store = current_k8s_corev1_api_client.read_namespaced_secret(
-                str(self.user_secret_store_id), REANA_KUBERNETES_NAMESPACE
+                str(self.user_secret_store_id), REANA_RUNTIME_KUBERNETES_NAMESPACE
             )
             k8s_user_secrets_store.data = k8s_user_secrets_store.data or {}
             return k8s_user_secrets_store

--- a/reana_commons/version.py
+++ b/reana_commons/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.7.0.dev20200602"
+__version__ = "0.7.0.dev20200619"


### PR DESCRIPTION
* In order to be able to deploy REANA in different Kubernetes
  namespaces we centralise the namespace configuration in
  `REANA_INFRASTRUCTURE_KUBERNETES_NAMESPACE` so every REANA component
  can rely on it when managing REANA related Kubernetes objects.
  This configuration happends at deployment time
  (closes reanahub/reana#274).
* Creates a new configuration variable to hold the namespace used
  to run runtime pods in REANA (closes reanahub/reana#268).
* Creates a central configuration variable for fully qualified
  infrastructure component names so any component can contact them
  from a different namespace.