### PR TITLE
config: load and parse runtime node label

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Version master (UNRELEASED)
 - Fixes memory leak in Bravado client instantiation. (`reanahub/reana-server#225 <https://github.com/reanahub/reana-server/issues/225>`_)
 - Makes maximum number of running workflows configurable.
 - Adds configurable prefix for component names.
+- Adds central variable for the runtime pods node selector label.
 - Allows specifying unpacked Docker images.
 - Upgrades minimum version of Kubernetes Python library to 11.
 - Centralises CephFS PVC name.

--- a/reana_commons/config.py
+++ b/reana_commons/config.py
@@ -117,6 +117,21 @@ REANA_RUNTIME_KUBERNETES_NAMESPACE = os.getenv(
 By default runtime pods will run in the same namespace as the infrastructure pods.
 """
 
+REANA_RUNTIME_KUBERNETES_NODE_LABEL = (
+    {
+        os.getenv("REANA_RUNTIME_KUBERNETES_NODE_LABEL")
+        .split("=")[0]: os.getenv("REANA_RUNTIME_KUBERNETES_NODE_LABEL")
+        .split("=")[1]
+    }
+    if os.getenv("REANA_RUNTIME_KUBERNETES_NODE_LABEL")
+    else {}
+)
+"""Kubernetes label (with format ``lable_name=lable_value``) which identifies the nodes where the runtime pods should run.
+
+If not set, the runtime pods run in any available node in the cluster.
+"""
+
+
 MQ_HOST = REANA_INFRASTRUCTURE_COMPONENTS_HOSTNAMES["message-broker"]
 """Message queue (RabbitMQ) server host name."""
 

--- a/reana_commons/version.py
+++ b/reana_commons/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.7.0a1"
+__version__ = "0.7.0a2"


### PR DESCRIPTION
* Needed by RWC and RJC to submit runtime pods to the correct nodes.