### PR TITLE
fix openapi spec order

### DIFF
--- a/reana_commons/openapi_specifications/reana_server.json
+++ b/reana_commons/openapi_specifications/reana_server.json
@@ -35,10 +35,10 @@
               "application/json": {
                 "announcement": "This is a QA instance",
                 "docs_url": "http://docs.reana.io/",
+                "chat_url": "https://mattermost.web.cern.ch/it-dep/channels/reana",
                 "client_pyvenv": "/afs/cern.ch/user/r/reana/public/reana/bin/activate",
                 "forum_url": "https://forum.reana.io/",
                 "local_users": true,
-                "chat_url": "https://mattermost.web.cern.ch/it-dep/channels/reana",
                 "pooling_secs": 15,
                 "sso": true
               }

--- a/reana_commons/version.py
+++ b/reana_commons/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.7.0a5"
+__version__ = "0.7.0a6"


### PR DESCRIPTION
- openapi: sort reana-server specs
- release: 0.7.0a6