### PR TITLE
Add accept-metadir operational option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+Version 0.7.1 (UNRELEASED)
+--------------------------
+
+- Adds support for restarting yadage workflows (through ``accept_metadir`` operational option).
+
 Version 0.7.0 (2020-10-20)
 --------------------------
 

--- a/reana_commons/operational_options.py
+++ b/reana_commons/operational_options.py
@@ -22,6 +22,7 @@ available_options = {
     "toplevel": {"yadage": "toplevel"},
     "initdir": {"yadage": "initdir"},
     "initfiles": {"yadage": "initfiles"},
+    "accept_metadir": {"yadage": "accept_metadir"},
 }
 
 


### PR DESCRIPTION
Add `accept-metadir` as an operational option for Yadage. By passing `accept-metadir` you allow overwriting an existing meta directory `_yadage`.

closes reanahub/reana-server#293