### PR TITLE
utils: fix get disk usage

### DIFF
--- a/reana_commons/utils.py
+++ b/reana_commons/utils.py
@@ -213,6 +213,9 @@ def get_disk_usage(directory, summarize=False, to_human_readable_units=None):
         command.append("-s")
     else:
         command.append("-a")
+    if not "Darwin" in platform.system():
+        # Default block size in GNU is KB
+        command.append("-b")
     command.append(absolute_path)
     disk_usage_info = subprocess.check_output(command).decode().split()
     # create pairs of (size, filename)


### PR DESCRIPTION
GNU `du` default block size is KB so we have to pass `-b` to get bytes (raw).

closes reanahub/reana#437