### PR TITLE
publisher: prioritize workflows in the queue

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,10 @@ Changes
 Version master (UNRELEASED)
 ---------------------------
 
-- Adds `get_disk_usage` utility function to calculate disk usage for a directory.
-- Centralises `fs` package dependency
+- Adds ``get_disk_usage`` utility function to calculate disk usage for a directory.
+- Centralises ``fs`` package dependency
+- Changes ``workflow-submission`` queue as a priority queue and allows to set the priority number on workflow submission.
+- Adds Yadage workflow specification loading utilities.
 
 Version 0.7.5 (UNRELEASED)
 --------------------------
@@ -17,7 +19,7 @@ Version 0.7.4 (2021-03-17)
 --------------------------
 
 - Adds new functions to serialise/deserialise job commands between REANA components.
-- Changes `reana_ready` function location to REANA-Server.
+- Changes ``reana_ready`` function location to REANA-Server.
 
 Version 0.7.3 (2021-02-22)
 --------------------------

--- a/reana_commons/config.py
+++ b/reana_commons/config.py
@@ -179,7 +179,7 @@ MQ_DEFAULT_FORMAT = "json"
 MQ_DEFAULT_EXCHANGE = ""
 """Message queue (RabbitMQ) exchange."""
 
-MQ_MAX_PRIORITY = 3
+MQ_MAX_PRIORITY = 100
 """Declare the queue as a priority queue and set the highest priority number."""
 
 MQ_DEFAULT_QUEUES = {
@@ -192,7 +192,7 @@ MQ_DEFAULT_QUEUES = {
         "routing_key": "workflow-submission",
         "exchange": MQ_DEFAULT_EXCHANGE,
         "durable": True,
-        "max_priority": MQ_MAX_PRIORITY
+        "max_priority": MQ_MAX_PRIORITY,
     },
 }
 """Default message queues."""

--- a/reana_commons/config.py
+++ b/reana_commons/config.py
@@ -179,6 +179,9 @@ MQ_DEFAULT_FORMAT = "json"
 MQ_DEFAULT_EXCHANGE = ""
 """Message queue (RabbitMQ) exchange."""
 
+MQ_MAX_PRIORITY = 3
+"""Declare the queue as a priority queue and set the highest priority number."""
+
 MQ_DEFAULT_QUEUES = {
     "jobs-status": {
         "routing_key": "jobs-status",
@@ -189,6 +192,7 @@ MQ_DEFAULT_QUEUES = {
         "routing_key": "workflow-submission",
         "exchange": MQ_DEFAULT_EXCHANGE,
         "durable": True,
+        "max_priority": MQ_MAX_PRIORITY
     },
 }
 """Default message queues."""

--- a/reana_commons/publisher.py
+++ b/reana_commons/publisher.py
@@ -157,13 +157,14 @@ class WorkflowSubmissionPublisher(BasePublisher):
         )
 
     def publish_workflow_submission(
-        self, user_id, workflow_id_or_name, parameters, priority=0
+        self, user_id, workflow_id_or_name, parameters, priority=0, min_job_memory=0
     ):
         """Publish workflow submission parameters."""
         msg = {
             "user": user_id,
             "workflow_id_or_name": workflow_id_or_name,
             "parameters": parameters,
-            "priority": priority,  # FIXME: this was added for debugging purposes, needs to be removed
+            "priority": priority,
+            "min_job_memory": min_job_memory,
         }
         self._publish(msg, priority)

--- a/reana_commons/version.py
+++ b/reana_commons/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.8.0a13"
+__version__ = "0.8.0a14"

--- a/reana_commons/yadage.py
+++ b/reana_commons/yadage.py
@@ -8,6 +8,7 @@
 """REANA Yadage Workflow utils."""
 
 import os
+import copy
 import json
 import yadageschemas
 from jsonschema import ValidationError
@@ -50,9 +51,13 @@ def yadage_load(workflow_file, toplevel=".", **kwargs):
         raise e
 
 
-def yadage_load_from_workspace(workspace_path, workflow_file, toplevel, **kwargs):
-    """Load yadage workflow specification from workspace path."""
+def yadage_load_from_workspace(workspace_path, reana_specification, toplevel, **kwargs):
+    """Load yadage workflow specification from workspace path.
+
+    :returns: Updated reana specification with loaded `yadage` workflow.
+    """
     workflow_workspace = "{0}/{1}".format(SHARED_VOLUME_PATH, workspace_path)
+    workflow_file = reana_specification["workflow"].get("file")
     workflow_file_abs_path = os.path.join(workflow_workspace, workflow_file)
     if not os.path.exists(workflow_file_abs_path):
         message = f"Workflow file {workflow_file} does not exist"
@@ -61,4 +66,7 @@ def yadage_load_from_workspace(workspace_path, workflow_file, toplevel, **kwargs
     if not toplevel.startswith("github:"):
         toplevel = os.path.join(workflow_workspace, toplevel)
 
-    return yadage_load(workflow_file, toplevel=toplevel, **kwargs)
+    workflow_spec = yadage_load(workflow_file, toplevel=toplevel, **kwargs)
+    reana_spec = copy.deepcopy(reana_specification)
+    reana_spec["workflow"]["specification"] = workflow_spec
+    return reana_spec

--- a/reana_commons/yadage.py
+++ b/reana_commons/yadage.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2021 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+"""REANA Yadage Workflow utils."""
+
+import os
+import json
+import yadageschemas
+from jsonschema import ValidationError
+
+from reana_commons.config import SHARED_VOLUME_PATH
+
+
+def yadage_load(workflow_file, toplevel=".", **kwargs):
+    """Validate and return yadage workflow specification.
+
+    :param workflow_file: A specification file compliant with
+        `yadage` workflow specification.
+    :type workflow_file: string
+    :param toplevel: URL/path for the workflow file
+    :type toplevel: string
+
+    :returns: A dictionary which represents the valid `yadage` workflow.
+    """
+    schema_name = "yadage/workflow-schema"
+    schemadir = None
+
+    specopts = {
+        "toplevel": toplevel,
+        "schema_name": schema_name,
+        "schemadir": schemadir,
+        "load_as_ref": False,
+    }
+
+    validopts = {
+        "schema_name": schema_name,
+        "schemadir": schemadir,
+    }
+
+    try:
+        return yadageschemas.load(
+            spec=workflow_file, specopts=specopts, validopts=validopts, validate=True,
+        )
+    except ValidationError as e:
+        e.message = str(e)
+        raise e
+
+
+def yadage_load_from_workspace(workspace_path, workflow_file, toplevel, **kwargs):
+    """Load yadage workflow specification from workspace path."""
+    workflow_workspace = "{0}/{1}".format(SHARED_VOLUME_PATH, workspace_path)
+    workflow_file_abs_path = os.path.join(workflow_workspace, workflow_file)
+    if not os.path.exists(workflow_file_abs_path):
+        message = f"Workflow file {workflow_file} does not exist"
+        raise Exception(message)
+
+    if not toplevel.startswith("github:"):
+        toplevel = os.path.join(workflow_workspace, toplevel)
+
+    return yadage_load(workflow_file, toplevel=toplevel, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ extras_require = {
     "docs": ["Sphinx>=1.4.4", "sphinx-rtd-theme>=0.1.9",],
     "tests": tests_require,
     "kubernetes": ["kubernetes>=11.0.0,<12.0.0",],
+    "yadage": ["yadage==0.20.1", "yadage-schemas==0.10.6",],
 }
 
 extras_require["all"] = []


### PR DESCRIPTION
closes https://github.com/reanahub/reana-server/issues/358

This PR declares `workflow-submission` queue as a [priority queue](https://www.rabbitmq.com/priority.html).
With `RabbitMQ` there is an option `x-max-priority` to do that which takes as an argument positive integer between 1 and 255, indicating the maximum priority the queue should support. Value 0 is the default one and means no priority for the message.
With `kombu` there is [max-priority](https://docs.celeryproject.org/projects/kombu/en/stable/reference/kombu.html#kombu.Queue.max_priority) option to do that:
```
For example if the value is 10, then messages delivered to this queue can have a priority value between 0 and 10, where 10 is the highest priority.
```

I have also amended `publisher` classes to have an additional `priority` argument. Right now when calling `publish_workflow_submission()` it is possible to define the priority of the workflow which is 0 by default.

Also, some logic to load Yadage specification was moved from `riena-client` since it's also needed in `reana-server`.
