### PR TITLE
publisher: delay rescheduled workflows and count number of retries

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Version master (UNRELEASED)
 - Centralises ``fs`` package dependency
 - Changes ``workflow-submission`` queue as a priority queue and allows to set the priority number on workflow submission.
 - Adds Yadage workflow specification loading utilities.
+- Changes ``workflow-submission`` exchange to delay rescheduled workflows and count number of retries.
 
 Version 0.7.5 (UNRELEASED)
 --------------------------

--- a/reana_commons/config.py
+++ b/reana_commons/config.py
@@ -179,6 +179,13 @@ MQ_DEFAULT_FORMAT = "json"
 MQ_DEFAULT_EXCHANGE = ""
 """Message queue (RabbitMQ) exchange."""
 
+MQ_WORKFLOW_SUBMISSION_EXCHANGE = {
+    "name": "workflow-submission",
+    "type": "x-delayed-message",
+    "arguments": {"x-delayed-type": "direct"},
+}
+"""Message queue (RabbitMQ) exchange for workflow submission."""
+
 MQ_MAX_PRIORITY = 100
 """Declare the queue as a priority queue and set the highest priority number."""
 
@@ -190,7 +197,7 @@ MQ_DEFAULT_QUEUES = {
     },
     "workflow-submission": {
         "routing_key": "workflow-submission",
-        "exchange": MQ_DEFAULT_EXCHANGE,
+        "exchange": MQ_WORKFLOW_SUBMISSION_EXCHANGE,
         "durable": True,
         "max_priority": MQ_MAX_PRIORITY,
     },

--- a/reana_commons/version.py
+++ b/reana_commons/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.8.0a15"
+__version__ = "0.8.0a16"


### PR DESCRIPTION
Creates a dedicated RabbitMQ exchange for a workflow submission with an ability to delay messages

Context: https://github.com/reanahub/reana-server/issues/118#issuecomment-854709746

PR is based on the instructions described in [RabbitMQ Delayed Message Plugin](https://github.com/rabbitmq/rabbitmq-delayed-message-exchange)

Testing can be done in a similar way as described in [this issue](https://github.com/reanahub/reana-server/pull/366).
`reana_ready()` in scheduler could be set to always return `False` to constantly reschedule the messages. In this way it should be possible to check that the messages are delayed as expected.

Closes https://github.com/reanahub/reana-server/issues/118
