### PR TITLE
Add K8S_USE_SECURITY_CONTEXT config variable (default: True)

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -6,6 +6,7 @@ The list of contributors in alphabetical order:
 - `Adelina Lintuluoto <https://orcid.org/0000-0002-0726-1452>`_
 - `Audrius Mecionis <https://orcid.org/0000-0002-3759-1663>`_
 - `Camila Diaz <https://orcid.org/0000-0001-5543-797X>`_
+- `Burt Holzman <https://orcid.org/0000-0001-5235-6314>`_
 - `Daniel Prelipcean <https://orcid.org/0000-0002-4855-194X>`_
 - `Diego Rodriguez <https://orcid.org/0000-0003-0649-2002>`_
 - `Dinos Kousidis <https://orcid.org/0000-0002-4914-4289>`_

--- a/reana_commons/config.py
+++ b/reana_commons/config.py
@@ -381,6 +381,17 @@ This a configuration set by the system administrators through Helm values at
 cluster creation time.
 """
 
+
+K8S_USE_SECURITY_CONTEXT = (
+    os.getenv("K8S_USE_SECURITY_CONTEXT", "True").lower() == "true"
+)
+"""Whether to use Kubernetes security contexts or not.
+
+This (enabled by default) runs workflows as the WORKFLOW_RUNTIME_USER_UID and
+WORKFLOW_RUNTIME_USER_GID.  It should be set to False for systems (like OpenShift)
+that assign ephemeral UIDs.
+"""
+
 REANA_INFRASTRUCTURE_KUBERNETES_SERVICEACCOUNT_NAME = os.getenv(
     "REANA_INFRASTRUCTURE_KUBERNETES_SERVICEACCOUNT_NAME"
 )


### PR DESCRIPTION
Some Kubernetes variants (OpenShift, OKD) assign ephemeral UIDs.
In these cases, security contexts and switching user aren't
needed or allowed, and this variable should be set via the
same named environment variable to False.