### PR TITLE
publisher: revert rescheduled workflows delay and remove number of retries

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,6 @@ Version master (UNRELEASED)
 - Centralises ``fs`` package dependency
 - Changes ``workflow-submission`` queue as a priority queue and allows to set the priority number on workflow submission.
 - Adds Yadage workflow specification loading utilities.
-- Changes ``workflow-submission`` exchange to delay rescheduled workflows and count number of retries.
 
 Version 0.7.5 (UNRELEASED)
 --------------------------

--- a/reana_commons/config.py
+++ b/reana_commons/config.py
@@ -179,13 +179,6 @@ MQ_DEFAULT_FORMAT = "json"
 MQ_DEFAULT_EXCHANGE = ""
 """Message queue (RabbitMQ) exchange."""
 
-MQ_WORKFLOW_SUBMISSION_EXCHANGE = {
-    "name": "workflow-submission",
-    "type": "x-delayed-message",
-    "arguments": {"x-delayed-type": "direct"},
-}
-"""Message queue (RabbitMQ) exchange for workflow submission."""
-
 MQ_MAX_PRIORITY = 100
 """Declare the queue as a priority queue and set the highest priority number."""
 
@@ -197,7 +190,7 @@ MQ_DEFAULT_QUEUES = {
     },
     "workflow-submission": {
         "routing_key": "workflow-submission",
-        "exchange": MQ_WORKFLOW_SUBMISSION_EXCHANGE,
+        "exchange": MQ_DEFAULT_EXCHANGE,
         "durable": True,
         "max_priority": MQ_MAX_PRIORITY,
     },

--- a/reana_commons/version.py
+++ b/reana_commons/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.8.0a17"
+__version__ = "0.8.0a18"


### PR DESCRIPTION
Reverts the changes done here: https://github.com/reanahub/reana-commons/commit/65836cdb3e9c7d23c15e2715dcd3cc75f9690c3c