### PR TITLE
snakemake: fix `load_operational_options_callback`

### DIFF
--- a/reana_commons/config.py
+++ b/reana_commons/config.py
@@ -418,3 +418,6 @@ REANA_COMPUTE_BACKENDS = {
     "slurm": "Slurm",
 }
 """REANA supported compute backends."""
+
+REANA_WORKFLOW_ENGINES = ["yadage", "cwl", "serial", "snakemake"]
+"""Available workflow engines."""

--- a/reana_commons/version.py
+++ b/reana_commons/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.8.0a19"
+__version__ = "0.8.0a20"

--- a/reana_commons/workflow_engine.py
+++ b/reana_commons/workflow_engine.py
@@ -67,7 +67,7 @@ workflow_engines = dict(
     serial=dict(load_operational_options_callback=load_json),
     yadage=dict(load_operational_options_callback=load_yadage_operational_options),
     # FIXME: Create `load_snakemake_operational_options`.
-    snakemake=dict(load_operational_options_callback=lambda x: None),
+    snakemake=dict(load_operational_options_callback=load_json),
 )
 
 
@@ -139,12 +139,12 @@ def create_workflow_engine_command(
     )
     @click.option(
         "--workflow-parameters",
-        help="JSON representation of parameters received by" " the workflow.",
+        help="JSON representation of parameters received by the workflow.",
         callback=load_json,
     )
     @click.option(
         "--operational-options",
-        help="Options to be passed to the workflow engine" " (i.e. caching).",
+        help="Options to be passed to the workflow engine (i.e. caching).",
         callback=workflow_engines[engine_type]["load_operational_options_callback"],
     )
     def run_workflow_engine_run_command(**kwargs):


### PR DESCRIPTION
closes reanahub/reana-client#531