### PR TITLE
models: delete dependency on SHARED_VOLUME_PATH

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -5,6 +5,7 @@ The list of contributors in alphabetical order:
 
 - `Adelina Lintuluoto <https://orcid.org/0000-0002-0726-1452>`_
 - `Audrius Mecionis <https://orcid.org/0000-0002-3759-1663>`_
+- `Camila Diaz <https://orcid.org/0000-0001-5543-797X>`_
 - `Daniel Prelipcean <https://orcid.org/0000-0002-4855-194X>`_
 - `Diego Rodriguez <https://orcid.org/0000-0003-0649-2002>`_
 - `Dinos Kousidis <https://orcid.org/0000-0002-4914-4289>`_

--- a/reana_commons/k8s/volumes.py
+++ b/reana_commons/k8s/volumes.py
@@ -67,6 +67,7 @@ def get_shared_volume(workflow_workspace):
             workflow_workspace, SHARED_VOLUME_PATH
         )
     mount_path = os.path.join(SHARED_VOLUME_PATH, workflow_workspace_relative_to_owner)
+
     volume_mount = {
         "name": REANA_SHARED_VOLUME_NAME,
         "mountPath": mount_path,
@@ -74,4 +75,19 @@ def get_shared_volume(workflow_workspace):
     }
 
     volume = get_reana_shared_volume()
+    return volume_mount, volume
+
+
+def get_workspace_volume(workflow_workspace):
+    """Get shared CephFS/hostPath workspace volume to a given job spec.
+
+    :param workflow_workspace: Absolute path to the job's workflow workspace.
+    :returns: Tuple consisting of the Kubernetes volumeMount and the volume.
+    """
+    volume_mount = {"name": "reana-workspace-volume", "mountPath": workflow_workspace}
+
+    volume = {
+        "name": "reana-workspace-volume",
+        "hostPath": {"path": workflow_workspace},
+    }
     return volume_mount, volume

--- a/reana_commons/openapi_specifications/reana_workflow_controller.json
+++ b/reana_commons/openapi_specifications/reana_workflow_controller.json
@@ -220,6 +220,13 @@
             "type": "string"
           },
           {
+            "description": "Shared root path to store the workflow",
+            "in": "query",
+            "name": "workspace_root_path",
+            "required": false,
+            "type": "string"
+          },
+          {
             "description": "JSON object including workflow parameters and workflow specification in JSON format (`yadageschemas.load()` output) with necessary data to instantiate a yadage workflow.",
             "in": "body",
             "name": "workflow",

--- a/reana_commons/openapi_specifications/reana_workflow_controller.json
+++ b/reana_commons/openapi_specifications/reana_workflow_controller.json
@@ -220,7 +220,7 @@
             "type": "string"
           },
           {
-            "description": "Shared root path to store the workflow",
+            "description": "A root path under which the workflow workspaces are stored.",
             "in": "query",
             "name": "workspace_root_path",
             "required": false,

--- a/reana_commons/utils.py
+++ b/reana_commons/utils.py
@@ -254,9 +254,7 @@ def get_disk_usage_info_paths(absolute_path, command, name_filter):
     if name_filter:
         path_list = []
         for _path in name_filter:
-            paths, _ = get_files_recursive_wildcard(
-                absolute_path.decode("utf-8"), _path
-            )
+            paths, _ = get_files_recursive_wildcard(absolute_path, _path)
             if paths:
                 path_list += paths
         if path_list:
@@ -284,10 +282,8 @@ def get_disk_usage(
 
     :return: List of dicts with file name and size.
     """
-    reana_fs = fs.open_fs(SHARED_VOLUME_PATH)
-    if not reana_fs.exists(directory):
+    if not os.path.exists(directory):
         raise REANAMissingWorkspaceError("Directory does not exist.")
-    absolute_path = reana_fs.getospath(directory)
     command = ["du"]
     if summarize:
         command.append("-s")
@@ -304,7 +300,7 @@ def get_disk_usage(
         name_filter = search.get("name")
         size_filter = search.get("size")
 
-    disk_usage_info = get_disk_usage_info_paths(absolute_path, command, name_filter)
+    disk_usage_info = get_disk_usage_info_paths(directory, command, name_filter)
     if disk_usage_info:
         filesize_pairs = list(zip(disk_usage_info[::2], disk_usage_info[1::2]))
         filesizes = []
@@ -313,7 +309,7 @@ def get_disk_usage(
             size = int(size)
             # trim workspace path in every file name, and transform bytes if necessary
             file_data = {
-                "name": name[len(absolute_path) :],
+                "name": name[len(directory) :],
                 "size": {"raw": size},
             }
             if to_human_readable_units:

--- a/reana_commons/version.py
+++ b/reana_commons/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.8.0a20"
+__version__ = "0.8.0a21"

--- a/reana_commons/workflow_engine.py
+++ b/reana_commons/workflow_engine.py
@@ -17,7 +17,6 @@ import signal
 import click
 
 from reana_commons.api_client import JobControllerAPIClient
-from reana_commons.config import SHARED_VOLUME_PATH
 from reana_commons.publisher import WorkflowStatusPublisher
 from reana_commons.utils import check_connection_to_job_controller
 
@@ -35,7 +34,6 @@ def load_yadage_operational_options(ctx, param, operational_options):
     """Decode and prepare operational options."""
     operational_options = load_json(ctx, param, operational_options)
     workflow_workspace = ctx.params.get("workflow_workspace")
-    workflow_workspace = "{0}/{1}".format(SHARED_VOLUME_PATH, workflow_workspace)
     toplevel = operational_options.get("toplevel", "")
     if not toplevel.startswith("github:"):
         toplevel = os.path.join(workflow_workspace, toplevel)

--- a/reana_commons/yadage.py
+++ b/reana_commons/yadage.py
@@ -12,8 +12,6 @@ import copy
 import yadageschemas
 from jsonschema import ValidationError
 
-from reana_commons.config import SHARED_VOLUME_PATH
-
 
 def yadage_load(workflow_file, toplevel=".", **kwargs):
     """Validate and return yadage workflow specification.
@@ -55,15 +53,14 @@ def yadage_load_from_workspace(workspace_path, reana_specification, toplevel, **
 
     :returns: Updated reana specification with loaded `yadage` workflow.
     """
-    workflow_workspace = "{0}/{1}".format(SHARED_VOLUME_PATH, workspace_path)
     workflow_file = reana_specification["workflow"].get("file")
-    workflow_file_abs_path = os.path.join(workflow_workspace, workflow_file)
+    workflow_file_abs_path = os.path.join(workspace_path, workflow_file)
     if not os.path.exists(workflow_file_abs_path):
         message = "Workflow file {} does not exist".format(workflow_file)
         raise Exception(message)
 
     if not toplevel.startswith("github:"):
-        toplevel = os.path.join(workflow_workspace, toplevel)
+        toplevel = os.path.join(workspace_path, toplevel)
 
     workflow_spec = yadage_load(workflow_file, toplevel=toplevel, **kwargs)
     reana_spec = copy.deepcopy(reana_specification)

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ readme = open("README.rst").read()
 history = open("CHANGES.rst").read()
 
 tests_require = [
-    "pytest-reana>=0.8.0a2,<0.9.0",
+    "pytest-reana>=0.8.0a6,<0.9.0",
     "pathlib>=1.0.1,<1.1.0",
 ]
 


### PR DESCRIPTION
Quit the dependency of upload-file,remove-file, list-files,mv-files  and download, relying directly on the full-path stored in the database

Closes reanahub/reana-db#94