### PR TITLE
snakemake: parse snakefile rules

### DIFF
--- a/reana_commons/version.py
+++ b/reana_commons/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.8.0a21"
+__version__ = "0.8.0a22"


### PR DESCRIPTION
Load an internal representation of the Snakemake workflow, similar
to serial workflows, to ease the validation tasks.

closes reanahub/reana-client#540