### PR TITLE
snakemake: include k8s_uid in spec for env validation

### DIFF
--- a/reana_commons/snakemake.py
+++ b/reana_commons/snakemake.py
@@ -65,7 +65,6 @@ def snakemake_load(workflow_file, **kwargs):
         workflow_file, configfiles=configfiles
     )
 
-    # FIXME: Adapt when supporting `kubernetes_uid`
     return {
         "steps": [
             {
@@ -75,6 +74,7 @@ def snakemake_load(workflow_file, **kwargs):
                 "params": dict(rule._params),
                 "outputs": dict(rule._output),
                 "commands": [rule.shellcmd],
+                "kubernetes_uid": rule.resources.get("kubernetes_uid"),
             }
             for rule in snakemake_workflow.rules
             if not rule.norun


### PR DESCRIPTION
closes reanahub/reana-workflow-engine-snakemake#8

**To test:**

1. Include a `kubernetes_uid` in the Snakefile under `resources`:
```diff
diff --git a/workflow/snakemake/Snakefile b/workflow/snakemake/Snakefile
index e7344f2..48a87d1 100644
--- a/workflow/snakemake/Snakefile
+++ b/workflow/snakemake/Snakefile
@@ -27,6 +27,8 @@ rule helloworld:
         "results/greetings.txt"
     container:
         "docker://python:2.7-slim"
+    resources:
+        kubernetes_uid=2000
     shell:
         "python {input.helloworld} "
         "--inputfile {input.inputfile} "
```
2. Call the `enviroments` validator:

```console
$ reana-client validate --environments -f reana-snakemake.yaml
...
==> Verifying REANA specification file... ~/code/reanahub/reana-demo-helloworld/reana-snakemake.yaml
  -> SUCCESS: Valid REANA specification file.
==> Verifying REANA specification parameters... 
  -> SUCCESS: REANA specification parameters appear valid.
==> Verifying workflow parameters and commands... 
  -> SUCCESS: Workflow parameters and commands appear valid.
==> Verifying dangerous workflow operations... 
  -> SUCCESS: Workflow operations appear valid.
==> Verifying environments in REANA specification file...
  -> SUCCESS: Environment image python:2.7-slim has the correct format.
  -> SUCCESS: Environment image python:2.7-slim exists locally.
  -> SUCCESS: Environment image python:2.7-slim exists in Docker Hub.
  -> WARNING: `kubernetes_uid` set to 2000. UID 0 was found.
```

3. Verify that the warning has the UID you set.