### PR TITLE
snakemake: add report operational option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,11 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update -y
+          sudo apt-get install python3-dev graphviz libgraphviz-dev pkg-config
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -y
           sudo apt install libcurl4-openssl-dev libssl-dev
           sudo apt-get install libgnutls28-dev
 
@@ -123,6 +128,11 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install python3-dev graphviz libgraphviz-dev pkg-config
 
       - name: Install Python dependencies
         run: |

--- a/reana_commons/operational_options.py
+++ b/reana_commons/operational_options.py
@@ -23,6 +23,7 @@ available_options = {
     "initdir": {"yadage": "initdir"},
     "initfiles": {"yadage": "initfiles"},
     "accept_metadir": {"yadage": "accept_metadir"},
+    "report": {"snakemake": "report"},
 }
 
 

--- a/reana_commons/version.py
+++ b/reana_commons/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.8.0a22"
+__version__ = "0.8.0a23"

--- a/reana_commons/workflow_engine.py
+++ b/reana_commons/workflow_engine.py
@@ -64,7 +64,6 @@ workflow_engines = dict(
     cwl=dict(load_operational_options_callback=load_cwl_operational_options),
     serial=dict(load_operational_options_callback=load_json),
     yadage=dict(load_operational_options_callback=load_yadage_operational_options),
-    # FIXME: Create `load_snakemake_operational_options`.
     snakemake=dict(load_operational_options_callback=load_json),
 )
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ extras_require = {
     "tests": tests_require,
     "kubernetes": ["kubernetes>=11.0.0,<12.0.0",],
     "yadage": ["adage==0.10.1", "yadage==0.20.1", "yadage-schemas==0.10.6",],
-    "snakemake": ["snakemake>=6.5.3,<6.6.0"],
+    "snakemake": ["snakemake[reports]>=6.5.3,<6.6.0"],
 }
 
 extras_require["all"] = []


### PR DESCRIPTION
- Include snakemake `reports` extra to install the dependencies needed.

closes #284
closes #288