### PR TITLE
utils: skip symlinks when creating `JobCache`

### DIFF
--- a/reana_commons/utils.py
+++ b/reana_commons/utils.py
@@ -117,6 +117,9 @@ def calculate_file_access_time(workflow_workspace):
     for subdir, dirs, files in os.walk(workflow_workspace):
         for file in files:
             file_path = os.path.join(subdir, file)
+            # skip symlinks
+            if os.path.islink(file_path):
+                continue
             access_times[file_path] = os.stat(file_path).st_atime
     return access_times
 


### PR DESCRIPTION
closes reanahub/reana#530

Caused exceptions when running [`reana-demo-cms-h4l`](https://github.com/reanahub/reana-demo-cms-h4l) example with Snakemake, as it's not possible to get the time of last access (`st_atime`) of a symlink.