### PR TITLE
setup: upgrade snakemake version

### DIFF
--- a/reana_commons/version.py
+++ b/reana_commons/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.8.0a25"
+__version__ = "0.8.0a26"

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ tests_require = [
 
 def get_snakemake_pkg(extras=""):
     """Get Snakemake dependency string, adding appropiate extras."""
-    return f"snakemake{extras}>=6.5.3,<6.6.0"
+    return f"snakemake{extras}>=6.8.0,<7.0.0"
 
 
 extras_require = {


### PR DESCRIPTION
closes #295

**To test:**
- Check that all examples run fine (`reana-dev run-example -w snakemake`), including `r-d-cms-h4l`.