### PR TITLE
snakemake: adapt env validation to fallback image

### DIFF
--- a/reana_commons/config.py
+++ b/reana_commons/config.py
@@ -442,3 +442,6 @@ REANA_COMPUTE_BACKENDS = {
 
 REANA_WORKFLOW_ENGINES = ["yadage", "cwl", "serial", "snakemake"]
 """Available workflow engines."""
+
+REANA_DEFAULT_SNAKEMAKE_ENV_IMAGE = "snakemake/snakemake:v6.8.0"
+"""Snakemake default job environment image."""

--- a/reana_commons/snakemake.py
+++ b/reana_commons/snakemake.py
@@ -69,7 +69,7 @@ def snakemake_load(workflow_file, **kwargs):
         "steps": [
             {
                 "name": rule.name,
-                "environment": rule._container_img.replace("docker://", ""),
+                "environment": (rule._container_img or "").replace("docker://", ""),
                 "inputs": dict(rule._input),
                 "params": dict(rule._params),
                 "outputs": dict(rule._output),

--- a/reana_commons/version.py
+++ b/reana_commons/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.8.0a26"
+__version__ = "0.8.0a27"


### PR DESCRIPTION
closes reanahub/reana-workflow-engine-snakemake#13
