### PR TITLE
config: fix default value for k8s keep alive jobs with status config

### DIFF
--- a/reana_commons/config.py
+++ b/reana_commons/config.py
@@ -419,9 +419,10 @@ KUBERNETES_MEMORY_FORMAT = r"(?:(?P<value_bytes>\d+)|(?P<value_unit>(\d+[.])?\d+
 )
 """Kubernetes valid memory format regular expression e.g. Ki, M, Gi, G, etc."""
 
-REANA_RUNTIME_KUBERNETES_KEEP_ALIVE_JOBS_WITH_STATUSES = os.getenv(
-    "REANA_RUNTIME_KUBERNETES_KEEP_ALIVE_JOBS_WITH_STATUSES", ""
-).split(",")
+statuses = os.getenv("REANA_RUNTIME_KUBERNETES_KEEP_ALIVE_JOBS_WITH_STATUSES", [])
+REANA_RUNTIME_KUBERNETES_KEEP_ALIVE_JOBS_WITH_STATUSES = (
+    statuses.split(",") if statuses else statuses
+)
 """Keep alive Kubernetes user runtime jobs depending on status.
 
 Keep alive both batch workflow jobs and invididual step jobs after termination


### PR DESCRIPTION
closes https://github.com/reanahub/reana-db/issues/148

To test:
- comment out [REANA_RUNTIME_KUBERNETES_KEEP_ALIVE_JOBS_WITH_STATUSES](https://github.com/reanahub/reana/blob/master/helm/configurations/values-dev.yaml#L11) value and redeploy
- run `roofit` example and check the logs of `run-batch`:
`2021-10-21 11:54:21,865 | root | kubernetes_job_monitor | WARNING | The configuration variable REANA_RUNTIME_KUBERNETES_KEEP_ALIVE_JOBS_WITH_STATUSES contains unknown statuses {''} which will be ignored, possibly causing jobs not to be cleaned up.` should no longer be there