### PR TITLE
publisher: log warning instead error when retrying publish

### DIFF
--- a/reana_commons/publisher.py
+++ b/reana_commons/publisher.py
@@ -71,7 +71,8 @@ class BasePublisher(object):
         """Instantiate a :class:`kombu.Producer`."""
         return self._connection.Producer(serializer=MQ_DEFAULT_FORMAT)
 
-    def __error_callback(self, exception, interval):
+    @staticmethod
+    def __error_callback(exception: Exception, interval: int) -> None:
         """Execute when there is an error while sending a message.
 
         :param exception: Exception which has been thrown while trying to send
@@ -79,8 +80,9 @@ class BasePublisher(object):
         :param interval: Interval in which the message delivery will be
             retried.
         """
-        logging.error("Error while publishing {}".format(exception))
-        logging.info("Retry in %s seconds.", interval)
+        logging.warning(
+            f"Error while publishing: {exception}. Retrying in {interval} seconds."
+        )
 
     def _publish(self, msg, priority=None):
         """Publish, handling retries, a message in the queue.
@@ -157,7 +159,7 @@ class WorkflowSubmissionPublisher(BasePublisher):
             MQ_DEFAULT_QUEUES[queue]["routing_key"],
             durable=MQ_DEFAULT_QUEUES[queue]["durable"],
             max_priority=MQ_DEFAULT_QUEUES[queue]["max_priority"],
-            **kwargs
+            **kwargs,
         )
 
     def publish_workflow_submission(


### PR DESCRIPTION
closes #305

After three unsuccessful retries, the `publish` call will fail. There is a possibility to add `try/catch` to:
https://github.com/reanahub/reana-commons/blob/86dd798259fbd7e5d4967a700243077fcc987012/reana_commons/publisher.py#L100-L107

I decided not to add `try/catch` here and leave the catching part (and decision what to do with it) on the calling code (basically, to engines). It is always possible to log an error and propagate further but I am not sure it is useful. Feel free to suggest a different option.

Testing:

1. start, for example, Yadage workflow
2. delete MQ pod using `kubectl delete pod` 
3. Check workflow-engine logs. You will see something similar:

```
2021-11-01 14:13:33,081 | reana-workflow-engine-yadage | MainThread | INFO | Workflow finished. Publishing...
2021-11-01 14:13:33,082 | root | MainThread | WARNING | Error while publishing: [Errno 104] Connection reset by peer. Retrying in 0 seconds.
2021-11-01 14:13:33,090 | root | MainThread | WARNING | Error while publishing: [Errno 111] Connection refused. Retrying in 1.0 seconds.
2021-11-01 14:13:34,098 | root | MainThread | WARNING | Error while publishing: [Errno 111] Connection refused. Retrying in 2.0 seconds.
2021-11-01 14:13:36,109 | root | MainThread | WARNING | Error while publishing: [Errno 111] Connection refused. Retrying in 2.0 seconds.
2021-11-01 14:13:38,118 | root | MainThread | WARNING | Error while publishing: Server unexpectedly closed connection. Retrying in 0 seconds.
2021-11-01 14:13:38,126 | root | MainThread | WARNING | Error while publishing: [Errno 111] Connection refused. Retrying in 1.0 seconds.
2021-11-01 14:13:39,134 | root | MainThread | WARNING | Error while publishing: [Errno 111] Connection refused. Retrying in 2.0 seconds.
2021-11-01 14:13:41,144 | root | MainThread | WARNING | Error while publishing: [Errno 111] Connection refused. Retrying in 2.0 seconds.
Traceback (most recent call last):
  ...
  ...
ConnectionResetError: [Errno 104] Connection reset by peer

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  ...
  ...
socket.gaierror: [Errno -5] No address associated with hostname

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  ...
  ...
ConnectionRefusedError: [Errno 111] Connection refused
```

The first couple of retries are from `publish_workflow_status` in `cli.py`. The second group of retries is from `reana_commons/workflow_engine.py`