### PR TITLE
tests: use higher memory limit

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ rule foo:
     container:
         "docker://python:3.10.0-buster"
     resources:
-        kubernetes_memory_limit="64Mi"
+        kubernetes_memory_limit="256Mi"
     shell:
         "mkdir -p results && touch {output}"
 
@@ -39,7 +39,7 @@ rule bar:
     container:
         "docker://python:3.10.0-buster"
     resources:
-        kubernetes_memory_limit="64Mi"
+        kubernetes_memory_limit="256Mi"
     shell:
         "mkdir -p results && touch {output}"
 
@@ -52,7 +52,7 @@ rule baz:
     container:
         "docker://python:3.10.0-buster"
     resources:
-        kubernetes_memory_limit="64Mi"
+        kubernetes_memory_limit="256Mi"
     shell:
         "mkdir -p results && touch {output}"
 """

--- a/tests/test_snakemake.py
+++ b/tests/test_snakemake.py
@@ -19,7 +19,7 @@ def test_snakemake_load(tmpdir, dummy_snakefile):
     metadata = snakemake_load(p.strpath)
 
     for step in metadata["steps"]:
-        assert step["kubernetes_memory_limit"] == "64Mi"
+        assert step["kubernetes_memory_limit"] == "256Mi"
 
     assert metadata["job_dependencies"] == {
         "foo": [],


### PR DESCRIPTION
Changes tests to use 256Mi instead of 64Mi. This is not really
necessary to do for tests, but it goes consistently in line with the
changes done in REANA demo examples, so that the old value of 64Mi
wouldn't pop up during grep etc in the code base.