### PR TITLE
setup: Set compatible releases for dependencies in 'yadage' extra

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -13,6 +13,7 @@ The list of contributors in alphabetical order:
 - `Kenyi Hurtado-Anampa <https://orcid.org/0000-0002-9779-3566>`_
 - `Leticia Wanderley <https://orcid.org/0000-0003-4649-6630>`_
 - `Marco Vidal <https://orcid.org/0000-0002-9363-4971>`_
+- `Matthew Feickert <https://orcid.org/0000-0003-4124-7862>`_
 - `Rokas Maciulaitis <https://orcid.org/0000-0003-1064-6967>`_
 - `Sinclert Perez <https://www.linkedin.com/in/sinclert>`_
 - `Tibor Simko <https://orcid.org/0000-0001-7202-5803>`_

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ extras_require = {
     "docs": ["Sphinx>=1.4.4", "sphinx-rtd-theme>=0.1.9",],
     "tests": tests_require,
     "kubernetes": ["kubernetes>=11.0.0,<12.0.0",],
-    "yadage": ["adage==0.10.1", "yadage==0.20.1", "yadage-schemas==0.10.6",],
+    "yadage": ["adage~=0.10.1", "yadage~=0.20.1", "yadage-schemas~=0.10.6"],
     "snakemake": [get_snakemake_pkg()],
     "snakemake_reports": [get_snakemake_pkg("[reports]")],
 }


### PR DESCRIPTION
Resolves #322 for the time being by applying @tiborsimko's suggestion 1 from https://github.com/reanahub/reana-commons/issues/322#issuecomment-997282837

> 1. If adage/yadage packages use semantic versioning strictly, so that we can rely on a fact that 0.20.N will have the same API for any N, then we can perhaps pin in `r-commons` in a manner like ">=0.20,<0.21" and then have a strict pin "==0.20.1" in `r-w-e-yadage` only.

This also comes with the promise that @lukasheinrich and I will adhere to SemVer and not introduce API breaking changes in any patch releases of libraries in the [yadage GitHub org](https://github.com/yadage).

---

Use compatible release syntax to set lower bounds on patch releases and upper bounds on minor releases of:
* `adage>=0.10.1,<0.11.0`
* `yadage>=0.20.1,<0.21.0`
* `yadage-schemas>=0.10.6,<0.11.0`

to allow for `reana-client` (`"reana-commons[yadage,snakemake]>=0.8.0,<0.9.0"` is a dependency of `reana-client` `v0.8.0`) to exist in environments with newer patch releases of yadage org libraries.