### PR TITLE
installation: support for Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2020, 2021 CERN.
+# Copyright (C) 2020, 2021, 2022 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: '3.8'
 
       - name: Check Python code formatting
         run: |
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: '3.8'
 
       - name: Check compliance with pep8, pyflakes and circular complexity
         run: |
@@ -61,7 +61,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: '3.8'
 
       - name: Check compliance with Python docstring conventions
         run: |
@@ -77,7 +77,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: '3.8'
 
       - name: Check Python manifest completeness
         run: |
@@ -93,7 +93,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: '3.8'
 
       - name: Install system dependencies
         run: |
@@ -117,7 +117,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:
       - name: Checkout
@@ -142,7 +142,7 @@ jobs:
         run: ./run-tests.sh --check-pytest
 
       - name: Codecov Coverage
-        if: matrix.python-version == 3.8
+        if: matrix.python-version == '3.8'
         uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+Version 0.8.2 (UNRELEASED)
+--------------------------
+
+- Adds support for Python 3.10.
+
 Version 0.8.1 (2021-12-21)
 ---------------------------
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (C) 2018, 2019, 2020, 2021 CERN.
+Copyright (C) 2018, 2019, 2020, 2021, 2022 CERN.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,22 +1,23 @@
 # This file is part of REANA.
-# Copyright (C) 2018, 2020, 2021 CERN.
+# Copyright (C) 2018, 2020, 2021, 2022 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-include .dockerignore
-include LICENSE
 include *.rst
 include *.sh
 include *.yaml
 include *.yml
+include .dockerignore
 include .flake8
+include LICENSE
 include pytest.ini
+include tox.ini
 prune docs/_build
-recursive-include reana_commons *.py
-recursive-include docs *.py
 recursive-include docs *.png
+recursive-include docs *.py
 recursive-include docs *.rst
 recursive-include docs *.txt
-recursive-include tests *.py
 recursive-include reana_commons *.json
+recursive-include reana_commons *.py
+recursive-include tests *.py

--- a/reana_commons/version.py
+++ b/reana_commons/version.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2018, 2019, 2020, 2021 CERN.
+# Copyright (C) 2018, 2019, 2020, 2021, 2022 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.8.1"
+__version__ = "0.8.2a1"

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2018, 2019, 2020, 2021 CERN.
+# Copyright (C) 2018, 2019, 2020, 2021, 2022 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -19,8 +19,7 @@ readme = open("README.rst").read()
 history = open("CHANGES.rst").read()
 
 tests_require = [
-    "pytest-reana>=0.8.0,<0.9.0",
-    "pathlib>=1.0.1,<1.1.0",
+    "pytest-reana>=0.8.1,<0.9.0",
 ]
 
 
@@ -96,6 +95,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python",
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+# This file is part of REANA.
+# Copyright (C) 2022 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+[tox]
+envlist = py36, py37, py38, py39, py310
+
+[testenv]
+deps = pytest
+       pytest-cov
+commands = {envpython} setup.py test


### PR DESCRIPTION
Adds support for Python 3.10.

Removes `pathlib` PyPI installation dependency since it is now part of
the standard Python library as of Python 3.4 and since we dropped the
support for Python 2.7.

Adds initial Tox configuration to simplify local testing of multiple
Python versions.

Closes reanahub/reana#602.