### PR TITLE
utils: fix file system usage calculation in get_disk_usage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Version 0.8.2 (UNRELEASED)
 - Adds workflow name validation utility.
 - Changes ``Snakemake`` loaded specification to include compute backends.
 - Changes OpenAPI specification with respect to return supported compute backends in ``info`` endpoint.
+- Fixes file system usage calculation on CephFS shares in ``get_disk_usage`` utility function.
 
 Version 0.8.1 (2021-12-21)
 ---------------------------

--- a/reana_commons/utils.py
+++ b/reana_commons/utils.py
@@ -292,8 +292,7 @@ def get_disk_usage(
     else:
         command.append("-a")
     if "Darwin" not in platform.system():
-        # Default block size in GNU is KB
-        command.append("-b")
+        command.append("--block-size=1")
 
     name_filter = None
     size_filter = None


### PR DESCRIPTION
- replace "-b" option, that equals to "--block-size=1 --apparent-size", with just "--block-size=1" in "du" command;
- "--apparent-size" option calculates file size usage, but we need file system usage.

closes reanahub/reana-client#579

How to test?

1. Run a few different workflows on a `master` branch. Note used disk space for them. Check disk usage in the "Profile" tab.
2. Check out this PR, redeploy cluster, run a few different workflows. Note used disk space. Check disk usage in the "Profile" tab.