### PR TITLE
setup: Set compatible releases for 'yadage' extra to be support 'yadage[viz]'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ extras_require = {
     "docs": ["Sphinx>=1.4.4", "sphinx-rtd-theme>=0.1.9",],
     "tests": tests_require,
     "kubernetes": ["kubernetes>=11.0.0,<12.0.0",],
-    "yadage": ["adage~=0.10.1", "yadage~=0.20.1", "yadage-schemas~=0.10.6"],
+    "yadage": ["adage~=0.10.3", "yadage~=0.20.2", "yadage-schemas~=0.10.6"],
     "snakemake": [get_snakemake_pkg()],
     "snakemake_reports": [get_snakemake_pkg("[reports]"), "pygraphviz<1.8"],
 }


### PR DESCRIPTION
Set the compatible releases for the 'yadage' extra to support:

* `adage>=0.10.3,<0.11.0`
* `yadage>=0.20.2,<0.21.0`

as `adage` `v0.10.3` and `yadage` `v0.20.2` solidify support for modern `pydot` which is
required for use of the `networkx` `v2.0` API (`networkx` is `adage`'s only core dependency).

This will allow for

```console
python -m pip install 'yadage[viz]>=0.20.2'
```

to collect all additional dependencies needed for `yadage` related visualization with `graphviz` (though the `graphviz` libraries still need to exist).

This should help to avoid things like https://github.com/reanahub/reana-workflow-engine-yadage/issues/220.

<details>
<summary>Example:</summary>

```console
$ docker run --rm -ti python:3.9 /bin/bash
root@be73ad116cb7:/# apt update && apt install -y -qq graphviz libgraphviz-dev
root@be73ad116cb7:/# python -m venv venv && . venv/bin/activate
(venv) root@be73ad116cb7:/# python -m pip --quiet install --upgrade pip setuptools wheel
(venv) root@be73ad116cb7:/# python -m pip install 'yadage[viz]'
Collecting yadage[viz]
  Downloading yadage-0.20.2-py3-none-any.whl (50 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 50.8/50.8 KB 1.8 MB/s eta 0:00:00
Collecting jsonpath-rw
  Downloading jsonpath-rw-1.4.0.tar.gz (13 kB)
  Preparing metadata (setup.py) ... done
Collecting jsonpointer>=1.10
  Downloading jsonpointer-2.2-py2.py3-none-any.whl (7.5 kB)
Collecting yadage-schemas
  Downloading yadage_schemas-0.10.7-py3-none-any.whl (19 kB)
Collecting click
  Downloading click-8.0.3-py3-none-any.whl (97 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 97.5/97.5 KB 4.6 MB/s eta 0:00:00
Collecting pyyaml
  Downloading PyYAML-6.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl (661 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 661.8/661.8 KB 10.4 MB/s eta 0:00:00
Collecting jsonref
  Downloading jsonref-0.2-py3-none-any.whl (9.3 kB)
Collecting checksumdir
  Downloading checksumdir-1.2.0-py3-none-any.whl (5.3 kB)
Collecting requests[security]>=2.9
  Downloading requests-2.27.1-py2.py3-none-any.whl (63 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 63.1/63.1 KB 5.0 MB/s eta 0:00:00
Collecting psutil
  Downloading psutil-5.9.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (280 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 280.4/280.4 KB 7.7 MB/s eta 0:00:00
Collecting adage>=0.10.2
  Downloading adage-0.10.3-py3-none-any.whl (18 kB)
Collecting packtivity
  Downloading packtivity-0.14.24-py3-none-any.whl (34 kB)
Collecting glob2
  Downloading glob2-0.7.tar.gz (10 kB)
  Preparing metadata (setup.py) ... done
Collecting jsonschema
  Downloading jsonschema-4.4.0-py3-none-any.whl (72 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 72.7/72.7 KB 5.8 MB/s eta 0:00:00
Collecting jq
  Downloading jq-1.2.1-cp39-cp39-manylinux2010_x86_64.whl (568 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 568.4/568.4 KB 4.1 MB/s eta 0:00:00
Collecting pydotplus>=2.0.0
  Downloading pydotplus-2.0.2.tar.gz (278 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 278.7/278.7 KB 2.5 MB/s eta 0:00:00
  Preparing metadata (setup.py) ... done
Collecting networkx>=2.4
  Downloading networkx-2.6.3-py3-none-any.whl (1.9 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.9/1.9 MB 1.8 MB/s eta 0:00:00
Collecting pygraphviz!=1.8,>=1.0
  Downloading pygraphviz-1.7.zip (118 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 118.8/118.8 KB 1.7 MB/s eta 0:00:00
  Preparing metadata (setup.py) ... done
Collecting pydot>=1.2.3
  Downloading pydot-1.4.2-py2.py3-none-any.whl (21 kB)
Collecting pyparsing>=2.0.1
  Downloading pyparsing-3.0.7-py3-none-any.whl (98 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 98.0/98.0 KB 2.4 MB/s eta 0:00:00
Collecting certifi>=2017.4.17
  Downloading certifi-2021.10.8-py2.py3-none-any.whl (149 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 149.2/149.2 KB 386.6 kB/s eta 0:00:00
Collecting urllib3<1.27,>=1.21.1
  Downloading urllib3-1.26.8-py2.py3-none-any.whl (138 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 138.7/138.7 KB 1.3 MB/s eta 0:00:00
Collecting charset-normalizer~=2.0.0
  Downloading charset_normalizer-2.0.11-py3-none-any.whl (39 kB)
Collecting idna<4,>=2.5
  Downloading idna-3.3-py3-none-any.whl (61 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 61.2/61.2 KB 1.3 MB/s eta 0:00:00
Collecting ply
  Downloading ply-3.11-py2.py3-none-any.whl (49 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 49.6/49.6 KB 1.0 MB/s eta 0:00:00
Collecting decorator
  Downloading decorator-5.1.1-py3-none-any.whl (9.1 kB)
Collecting six
  Downloading six-1.16.0-py2.py3-none-any.whl (11 kB)
Collecting attrs>=17.4.0
  Downloading attrs-21.4.0-py2.py3-none-any.whl (60 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 60.6/60.6 KB 1.5 MB/s eta 0:00:00
Collecting pyrsistent!=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
  Downloading pyrsistent-0.18.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (115 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 115.6/115.6 KB 1.9 MB/s eta 0:00:00
Collecting mock
  Downloading mock-4.0.3-py3-none-any.whl (28 kB)
Building wheels for collected packages: pydotplus, glob2, jsonpath-rw, pygraphviz
  Building wheel for pydotplus (setup.py) ... done
  Created wheel for pydotplus: filename=pydotplus-2.0.2-py3-none-any.whl size=24575 sha256=b854af30968b6deaf44892fe7cc3c8be2a0a3a39888acf3f33b5f7952397409a
  Stored in directory: /root/.cache/pip/wheels/89/e5/de/6966007cf223872eedfbebbe0e074534e72e9128c8fd4b55eb
  Building wheel for glob2 (setup.py) ... done
  Created wheel for glob2: filename=glob2-0.7-py2.py3-none-any.whl size=9320 sha256=e7ee91173ec554de9d4f187f39e4e4691dbeda8e1ce99de2945d99cd2760ea4e
  Stored in directory: /root/.cache/pip/wheels/c0/dd/ee/ba6164807de7570971e8f160dbe6a4178ff4e5922f48c093be
  Building wheel for jsonpath-rw (setup.py) ... done
  Created wheel for jsonpath-rw: filename=jsonpath_rw-1.4.0-py3-none-any.whl size=15147 sha256=ca6840fc048596163bd969e2fe7d81f3ca5b13ede5865162e7eb0b6b02eaec16
  Stored in directory: /root/.cache/pip/wheels/04/56/46/9ae68fd2e2115ef977e84ce5b86440421eba7059b36eeea416
  Building wheel for pygraphviz (setup.py) ... done
  Created wheel for pygraphviz: filename=pygraphviz-1.7-cp39-cp39-linux_x86_64.whl size=106196 sha256=f33ee9da1a3d68e188137a0068012a61e51b6df1c1df3ae62362c00189bc8bc7
  Stored in directory: /root/.cache/pip/wheels/c9/3d/ec/7b5e6d9cef1f021ca3264ed44a703b88fb222e033c4a0e6dfe
Successfully built pydotplus glob2 jsonpath-rw pygraphviz
Installing collected packages: ply, jsonref, glob2, certifi, urllib3, six, pyyaml, pyrsistent, pyparsing, pygraphviz, psutil, networkx, mock, jsonpointer, jq, idna, decorator, click, checksumdir, charset-normalizer, attrs, requests, pydotplus, pydot, jsonschema, jsonpath-rw, adage, yadage-schemas, packtivity, yadage
Successfully installed adage-0.10.3 attrs-21.4.0 certifi-2021.10.8 charset-normalizer-2.0.11 checksumdir-1.2.0 click-8.0.3 decorator-5.1.1 glob2-0.7 idna-3.3 jq-1.2.1 jsonpath-rw-1.4.0 jsonpointer-2.2 jsonref-0.2 jsonschema-4.4.0 mock-4.0.3 networkx-2.6.3 packtivity-0.14.24 ply-3.11 psutil-5.9.0 pydot-1.4.2 pydotplus-2.0.2 pygraphviz-1.7 pyparsing-3.0.7 pyrsistent-0.18.1 pyyaml-6.0 requests-2.27.1 six-1.16.0 urllib3-1.26.8 yadage-0.20.2 yadage-schemas-0.10.7
(venv) root@be73ad116cb7:/# python -m pip list | grep 'adage\|pydot\|networkx'
adage              0.10.3
networkx           2.6.3
pydot              1.4.2
pydotplus          2.0.2
yadage             0.20.2
yadage-schemas     0.10.7
```

</details>