### PR TITLE
publisher: add retry count to workflow submission publisher

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+Version 0.8.5 (UNRELEASED)
+--------------------------
+
+- Adds ``retry_count`` parameter to WorkflowSubmissionPublisher.
+
 Version 0.8.4 (2022-02-08)
 --------------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changes
 =======
 
-Version 0.8.5 (UNRELEASED)
+Version 0.8.5 (2022-02-23)
 --------------------------
 
 - Adds ``retry_count`` parameter to WorkflowSubmissionPublisher.

--- a/reana_commons/publisher.py
+++ b/reana_commons/publisher.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2018, 2019, 2020, 2021 CERN.
+# Copyright (C) 2018, 2019, 2020, 2021, 2022 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -9,6 +9,7 @@
 
 import json
 import logging
+from typing import Optional
 
 from kombu import Connection, Exchange, Queue
 
@@ -163,7 +164,13 @@ class WorkflowSubmissionPublisher(BasePublisher):
         )
 
     def publish_workflow_submission(
-        self, user_id, workflow_id_or_name, parameters, priority=0, min_job_memory=0,
+        self,
+        user_id,
+        workflow_id_or_name,
+        parameters,
+        priority=0,
+        min_job_memory=0,
+        retry_count: Optional[int] = None,
     ):
         """Publish workflow submission parameters."""
         msg = {
@@ -173,4 +180,7 @@ class WorkflowSubmissionPublisher(BasePublisher):
             "priority": priority,
             "min_job_memory": min_job_memory,
         }
+
+        if retry_count:
+            msg["retry_count"] = retry_count
         self._publish(msg, priority)

--- a/reana_commons/version.py
+++ b/reana_commons/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.8.4"
+__version__ = "0.8.5"


### PR DESCRIPTION
- because workflow submission publisher is used only in r-server, it makes sense to move it there;

closes reanahub/reana-server#436