### PR TITLE
spec: improve spec loading functionality to support remote working directories

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Version 0.9.0 (UNRELEASED)
 - Adds REANA specification validation and loading logic from ``reana-client``.
 - Adds support for networking/v1 API to Kubernetes Python client.
 - Adds new ``/api/launch`` endpoint that allows running workflows from remote sources.
+- Changes REANA specification loading functionality to allow specifying different working directories.
 
 Version 0.8.5 (2022-02-23)
 --------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -207,5 +207,5 @@ texinfo_documents = [
 
 # Intersphinx configuration
 intersphinx_mapping = {
-    "kombu": ("http://docs.celeryproject.org/projects/kombu/en/latest/", None),
+    "kombu": ("https://docs.celeryq.dev/projects/kombu/en/latest/", None),
 }

--- a/reana_commons/version.py
+++ b/reana_commons/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.9.0a3"
+__version__ = "0.9.0a4"


### PR DESCRIPTION
closes https://github.com/reanahub/reana-server/issues/456

Most of the workflow engines were not working (except `serial`) when launched from web UI. This is because the working directory is different when loading the specs and relative paths were no longer working. This PR fixes this issue by specifying different configs for each of the engine.

To test:
- Make sure that all the workflow engines are working both from the launcher and CLI
- To test `roofit` via launcher:
```
https://localhost:30443/launch?url=https://github.com/reanahub/reana-demo-root6-roofit.git&spec=reana.yaml&name=roofit-serial
https://localhost:30443/launch?url=https://github.com/reanahub/reana-demo-root6-roofit.git&spec=reana-yadage.yaml&name=roofit-yadage
https://localhost:30443/launch?url=https://github.com/reanahub/reana-demo-root6-roofit.git&spec=reana-cwl.yaml&name=roofit-cwl
https://localhost:30443/launch?url=https://github.com/reanahub/reana-demo-root6-roofit.git&spec=reana-snakemake.yaml&name=roofit-snakemake
```
- To test `roofit` via CLI:
```
reana-client run -w roofit-serial-cli -f reana.yaml
reana-client run -w roofit-yadage-cli -f reana-yadage.yaml
reana-client run -w roofit-cwl-cli -f reana-cwl.yaml
reana-client run -w roofit-snakemake-cli -f reana-snakemake.yaml
```
- Test another demos, example:
```
https://localhost:30443/launch?url=https://github.com/reanahub/reana-demo-bsm-search&spec=reana.yaml&name=bsm-search
```