### PR TITLE
openapi: updated reana-server openapi disk usage specification

### DIFF
--- a/reana_commons/openapi_specifications/reana_server.json
+++ b/reana_commons/openapi_specifications/reana_server.json
@@ -1639,6 +1639,14 @@
             "name": "parameters",
             "required": false,
             "schema": {
+              "properties": {
+                "search": {
+                  "type": "string"
+                },
+                "summarize": {
+                  "type": "boolean"
+                }
+              },
               "type": "object"
             }
           }


### PR DESCRIPTION
Updates the openapi disk usage specification, so that it can be more useful in `reana-client-go`