### PR TITLE
openapi: fix response schema of delete_file()

### DIFF
--- a/reana_commons/openapi_specifications/reana_server.json
+++ b/reana_commons/openapi_specifications/reana_server.json
@@ -3690,9 +3690,33 @@
         ],
         "responses": {
           "200": {
-            "description": "Requests succeeded. The file has been downloaded.",
+            "description": "Request succeeded. Details about deleted files and failed deletions are returned.",
             "schema": {
-              "type": "file"
+              "properties": {
+                "deleted": {
+                  "additionalProperties": {
+                    "properties": {
+                      "size": {
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "object"
+                },
+                "failed": {
+                  "additionalProperties": {
+                    "properties": {
+                      "error": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
             }
           },
           "403": {


### PR DESCRIPTION
closes https://github.com/reanahub/reana-client-go/issues/96