### PR TITLE
k8s: add krb5 sidecar container configuration to renew ticket

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ Version 0.9.0 (UNRELEASED)
 - Adds support for networking/v1 API to Kubernetes Python client.
 - Adds new ``/api/launch`` endpoint that allows running workflows from remote sources.
 - Adds support for specifying ``slurm_partition`` and ``slurm_time`` for Slurm compute backend jobs.
-- Adds generation of Kerberos sidecar container's configuration.
+- Adds generation of Kerberos init and renew container's configuration.
 - Adds specification of ``retention_days`` in ``reana.yaml`` JSON schema.
 - Adds support for Unicode characters inside email body.
 - Changes REANA specification loading functionality to allow specifying different working directories.

--- a/reana_commons/config.py
+++ b/reana_commons/config.py
@@ -485,8 +485,21 @@ KRB5_CONTAINER_IMAGE = os.getenv(
 )
 """Default docker image of KRB5 sidecar container."""
 
-KRB5_CONTAINER_NAME = "krb5"
-"""Name of KRB5 sidecar container."""
+KRB5_INIT_CONTAINER_NAME = "krb5-init"
+"""Name of KRB5 init container."""
+
+KRB5_RENEW_CONTAINER_NAME = "krb5-renew"
+"""Name of KRB5 sidecar container used for ticket renewal."""
+
+KRB5_STATUS_FILE_LOCATION = "/krb5_cache/status_file"
+"""Status file path used to terminate KRB5 renew container when the main
+job finishes."""
+
+KRB5_STATUS_FILE_CHECK_INTERVAL = 15
+"""Time interval in seconds between checks to the status file."""
+
+KRB5_TICKET_RENEW_INTERVAL = 21600  # 6 hours
+"""Time interval in seconds between renewals of the KRB5 ticket."""
 
 KRB5_TOKEN_CACHE_LOCATION = "/krb5_cache/"
 """Directory of Kerberos tokens cache, shared between job/engine & KRB5 container. It

--- a/reana_commons/version.py
+++ b/reana_commons/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.9.0a16"
+__version__ = "0.9.0a17"


### PR DESCRIPTION
closes https://github.com/reanahub/reana-job-controller/issues/375

Please note that `reanahub/reana-auth-krb5:1.0.1` image does not have `krenew` package. There is a [PR](https://github.com/reanahub/reana-auth-krb5/pull/8) to include it. Until it's merged and released testing could be done with `audrium/reana-auth-krb5:20221201` image specified [here](https://github.com/reanahub/reana-commons/blob/master/reana_commons/config.py#L484).

TODO:
- [ ] <del>Modify `KRB5_CONTAINER_IMAGE` version once [reana-auth-krb5 PR](https://github.com/reanahub/reana-auth-krb5/pull/8) is  merged and released</del>
- [x] Make a new release and update requirements of all the rest PRs