### PR TITLE
k8s: print timestamp in krb5 sidecar container when renewing ticket

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+Version 0.9.1 (2023-01-18)
+--------------------------
+
+- Changes Kerberos renew container's configuration to log each ticket renewal.
+
 Version 0.9.0 (2022-12-13)
 --------------------------
 

--- a/reana_commons/k8s/kerberos.py
+++ b/reana_commons/k8s/kerberos.py
@@ -113,7 +113,8 @@ def get_kerberos_k8s_config(
             (
                 "SECONDS=0; "
                 f"while ! test -f {KRB5_STATUS_FILE_LOCATION}; do "
-                f"if [ $SECONDS -ge {KRB5_TICKET_RENEW_INTERVAL} ]; then kinit -R; SECONDS=0; fi; "
+                f"if [ $SECONDS -ge {KRB5_TICKET_RENEW_INTERVAL} ]; then "
+                'echo "Renewing Kerberos ticket: $(date)"; kinit -R; SECONDS=0; fi; '
                 f"sleep {KRB5_STATUS_FILE_CHECK_INTERVAL}; done"
             )
         ],

--- a/reana_commons/version.py
+++ b/reana_commons/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"


### PR DESCRIPTION
closes https://github.com/reanahub/reana-job-controller/issues/375