### PR TITLE
docs: add .readthedocs.yaml to migrate to RTD v2

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,19 @@
+# This file is part of REANA.
+# Copyright (C) 2023 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -13,6 +13,7 @@ include .flake8
 include LICENSE
 include pytest.ini
 include tox.ini
+exclude .readthedocs.yaml
 prune docs/_build
 recursive-include docs *.png
 recursive-include docs *.py


### PR DESCRIPTION
Closes reanahub/reana#710.