### PR TITLE
setup: Set lower bound of PyYAML v6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ install_requires = [
     "jsonschema[format]>=3.0.1,<4.0.0",
     "kombu>=4.6",
     "mock>=3.0,<4",
-    "PyYAML>=5.1,<6.0",
+    "PyYAML>=6.0",
     "Werkzeug>=0.14.1",
     "wcmatch>=8.3,<8.5",
 ]


### PR DESCRIPTION
Resolves #399

Environment isolated builds of `PyYAML` `v5.X` are broken by `Cython` `v3.0` (c.f. https://github.com/yaml/pyyaml/issues/724). As this will not be patched the only reasonable approach forward is to set a new lower bound of `PyYAML` `v6.0`.

A patch release of `reana-commons` will be needed following this PR to unbreak the rest of the `reana` ecosystem.