### PR TITLE
global: merge maint-0.9

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,11 @@ Version 0.9.3 (UNRELEASED)
 - Fixes the verbs used to describe changes to the status of a workflow in order to avoid incorrect phrases such as ``workflow has been failed``.
 - Fixes the loading of Snakemake and CWL workflow specifications when no parameters are specified.
 
+Version 0.9.2.1 (2023-07-19)
+----------------------------
+
+- Changes ``PyYAML`` dependency version bounds in order to fix installation on Python 3.10+.
+
 Version 0.9.2 (2023-02-10)
 --------------------------
 

--- a/reana_commons/openapi_specifications/reana_job_controller.json
+++ b/reana_commons/openapi_specifications/reana_job_controller.json
@@ -122,9 +122,8 @@
   "info": {
     "description": "REANA Job Controller API",
     "title": "reana-job-controller",
-    "version": "0.9.0a5"
+    "version": "0.9.1a2"
   },
-  "parameters": {},
   "paths": {
     "/apispec": {},
     "/job_cache": {
@@ -413,6 +412,5 @@
       }
     }
   },
-  "swagger": "2.0",
-  "tags": []
+  "swagger": "2.0"
 }

--- a/reana_commons/openapi_specifications/reana_server.json
+++ b/reana_commons/openapi_specifications/reana_server.json
@@ -1,11 +1,9 @@
 {
-  "definitions": {},
   "info": {
     "description": "Submit workflows to be run on REANA Cloud",
     "title": "REANA Server",
     "version": "0.9.1a3"
   },
-  "parameters": {},
   "paths": {
     "/account/settings/linkedaccounts/": {},
     "/account/settings/linkedaccounts/static/{filename}": {},
@@ -4450,6 +4448,5 @@
     "/signin": {},
     "/signup/": {}
   },
-  "swagger": "2.0",
-  "tags": []
+  "swagger": "2.0"
 }

--- a/reana_commons/openapi_specifications/reana_workflow_controller.json
+++ b/reana_commons/openapi_specifications/reana_workflow_controller.json
@@ -1,11 +1,9 @@
 {
-  "definitions": {},
   "info": {
     "description": "Submit and manage workflows",
     "title": "REANA Workflow Controller",
-    "version": "0.9.0a6"
+    "version": "0.9.1a2"
   },
-  "parameters": {},
   "paths": {
     "/api/workflows": {
       "get": {
@@ -1550,6 +1548,5 @@
       }
     }
   },
-  "swagger": "2.0",
-  "tags": []
+  "swagger": "2.0"
 }

--- a/reana_commons/version.py
+++ b/reana_commons/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.9.3a3"
+__version__ = "0.9.3a4"

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ install_requires = [
     "jsonschema[format]>=3.0.1,<4.0.0",
     "kombu>=4.6",
     "mock>=3.0,<4",
-    "PyYAML>=5.1,<6.0",
+    "PyYAML>=5.1,<7.0",
     "Werkzeug>=0.14.1",
     "wcmatch>=8.3,<8.5",
 ]


### PR DESCRIPTION
- docs: switch to stable version of kombu
- docs: fix docstrings for kombu class references
- setup: bump upper pin of PyYAML
- release: 0.9.2.1
- openapi: update specs
- release: 0.9.3a4

Closes https://github.com/reanahub/reana-commons/issues/399