### PR TITLE
docker: podman-friendly image locations

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -2,9 +2,15 @@ codecov:
   require_ci_to_pass: yes
 
 coverage:
-  precision: 2
-  round: down
-  range: "80...100"
+  status:
+    patch:
+      default:
+        informational: true
+    project:
+      default:
+        base: auto
+        target: auto
+        threshold: 2%
 
 parsers:
   gcov:

--- a/reana_commons/config.py
+++ b/reana_commons/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2018, 2019, 2020, 2021, 2022 CERN.
+# Copyright (C) 2018, 2019, 2020, 2021, 2022, 2023 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -467,7 +467,7 @@ REANA_COMPUTE_BACKENDS = {
 REANA_WORKFLOW_ENGINES = ["yadage", "cwl", "serial", "snakemake"]
 """Available workflow engines."""
 
-REANA_DEFAULT_SNAKEMAKE_ENV_IMAGE = "snakemake/snakemake:v6.8.0"
+REANA_DEFAULT_SNAKEMAKE_ENV_IMAGE = "docker.io/snakemake/snakemake:v6.8.0"
 """Snakemake default job environment image."""
 
 REANA_JOB_CONTROLLER_CONNECTION_CHECK_SLEEP = float(
@@ -481,7 +481,7 @@ COMMAND_DANGEROUS_OPERATIONS = ["sudo ", "cd /"]
 # Kerberos configurations
 
 KRB5_CONTAINER_IMAGE = os.getenv(
-    "KRB5_CONTAINER_IMAGE", "reanahub/reana-auth-krb5:1.0.1"
+    "KRB5_CONTAINER_IMAGE", "docker.io/reanahub/reana-auth-krb5:1.0.1"
 )
 """Default docker image of KRB5 sidecar container."""
 

--- a/reana_commons/openapi_specifications/reana_job_controller.json
+++ b/reana_commons/openapi_specifications/reana_job_controller.json
@@ -195,7 +195,7 @@
                       "atlas.cern.ch",
                       "atlas-condb.cern.ch"
                     ],
-                    "docker_img": "busybox",
+                    "docker_img": "docker.io/library/busybox",
                     "job_id": "1612a779-f3fa-4344-8819-3d12fa9b9d90",
                     "max_restart_count": 3,
                     "restart_count": 0,
@@ -207,7 +207,7 @@
                       "atlas.cern.ch",
                       "atlas-condb.cern.ch"
                     ],
-                    "docker_img": "busybox",
+                    "docker_img": "docker.io/library/busybox",
                     "job_id": "2e4bbc1d-db5e-4ee0-9701-6e2b1ba55c20",
                     "max_restart_count": 3,
                     "restart_count": 0,
@@ -300,7 +300,7 @@
                     "atlas.cern.ch",
                     "atlas-condb.cern.ch"
                   ],
-                  "docker_img": "busybox",
+                  "docker_img": "docker.io/library/busybox",
                   "job_id": "cdcf48b1-c2f3-4693-8230-b066e088c6ac",
                   "max_restart_count": 3,
                   "restart_count": 0,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2018, 2019, 2021 CERN.
+# Copyright (C) 2018, 2019, 2021, 2023 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -27,7 +27,7 @@ rule foo:
     output:
         "results/foo.txt"
     container:
-        "docker://python:3.10.0-buster"
+        "docker://docker.io/library/python:3.10.0-buster"
     resources:
         kubernetes_memory_limit="256Mi"
     shell:
@@ -39,7 +39,7 @@ rule bar:
     output:
         "results/bar.txt"
     container:
-        "docker://python:3.10.0-buster"
+        "docker://docker.io/library/python:3.10.0-buster"
     resources:
         kubernetes_memory_limit="256Mi"
     shell:
@@ -52,7 +52,7 @@ rule baz:
     output:
         "results/baz.txt"
     container:
-        "docker://python:3.10.0-buster"
+        "docker://docker.io/library/python:3.10.0-buster"
     resources:
         kubernetes_memory_limit="256Mi"
     shell:


### PR DESCRIPTION
Adds fully qualified canonical locations of container images, making the container technology setup podman-friendly.

Closes reanahub/reana#729.