### PR TITLE
validation: issue warning for extra keys in REANA specs

### DIFF
--- a/reana_commons/openapi_specifications/reana_server.json
+++ b/reana_commons/openapi_specifications/reana_server.json
@@ -582,6 +582,18 @@
                 "message": {
                   "type": "string"
                 },
+                "validation_warnings": {
+                  "description": "Dictionary of validation warnings, if any. Each key is a property that was not correctly validated.",
+                  "properties": {
+                    "additional_properties": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
                 "workflow_id": {
                   "type": "string"
                 },
@@ -589,6 +601,11 @@
                   "type": "string"
                 }
               },
+              "required": [
+                "workflow_id",
+                "workflow_name",
+                "message"
+              ],
               "type": "object"
             }
           },

--- a/reana_commons/version.py
+++ b/reana_commons/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.9.3a4"
+__version__ = "0.9.3a5"


### PR DESCRIPTION
When validating the REANA specification, whitelist some keys in the JSON
schema (`additionalProperties`) that, when not correctly validated, will
 issue a warning rather than raising a critical error.
 The list of warnings is returned by the validator function.

Closes reanahub/reana-client#660
