### PR TITLE
adding the configuration for the IGWN software package already present on CVMFS

### DIFF
--- a/reana_commons/config.py
+++ b/reana_commons/config.py
@@ -264,6 +264,7 @@ CVMFS_REPOSITORIES = {
     "na62.cern.ch": "na62",
     "projects.cern.ch": "projects",
     "sft.cern.ch": "sft",
+    "software.igwn.org": "igwn", 
     "unpacked.cern.ch": "unpacked",
 }
 """CVMFS repositories available for mounting."""

--- a/reana_commons/config.py
+++ b/reana_commons/config.py
@@ -264,7 +264,7 @@ CVMFS_REPOSITORIES = {
     "na62.cern.ch": "na62",
     "projects.cern.ch": "projects",
     "sft.cern.ch": "sft",
-    "software.igwn.org": "igwn", 
+    "software.igwn.org": "igwn",
     "unpacked.cern.ch": "unpacked",
 }
 """CVMFS repositories available for mounting."""


### PR DESCRIPTION
The IGWN (International Gravitational-Wave Observatory Network), an ESCAPE collaborator, is testing Reana workflows and needs access to their software, which is already available through CVMFS: https://computing.docs.ligo.org/guide/cvmfs/. 
This one-line addition will allow them to specify the CVMFS mount in the `reana.yaml` file as:
```
resources:
        cvmfs:
          - software.igwn.org
```