### PR TITLE
specification: reformat load_reana_spec

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+Version 0.9.4 (UNRELEASED)
+--------------------------
+
+- Changes validation of REANA specification to expose functions for loading workflow input parameters and workflow specifications.
+
 Version 0.9.3 (2023-09-26)
 --------------------------
 

--- a/reana_commons/version.py
+++ b/reana_commons/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.9.3"
+__version__ = "0.9.4a1"


### PR DESCRIPTION
Change `load_reana_spec` by including two functions
`load_workflow_spec_from_reana_yaml` and `load_input_parameters` to
respectively load the workflow specification from the REANA yaml
dictionary and to load the CWL / Snakemake input parameters inside the
REANA specification dictionary from the workflow specification file.

Closes reanahub/reana-client#666
