### PR TITLE
openapi: add missing run_number field to start_workflow response

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 Version 0.9.4 (UNRELEASED)
 --------------------------
 
+- Changes the OpenAPI specification of the ``start_workflow`` endpoint's response to add missing ``run_number`` field.
 - Changes validation of REANA specification to expose functions for loading workflow input parameters and workflow specifications.
 - Fixes the mounting of CVMFS volumes for the REANA deployments that use non-default Kubernetes namespace.
 

--- a/reana_commons/openapi_specifications/reana_server.json
+++ b/reana_commons/openapi_specifications/reana_server.json
@@ -2,7 +2,7 @@
   "info": {
     "description": "Submit workflows to be run on REANA Cloud",
     "title": "REANA Server",
-    "version": "0.9.1a3"
+    "version": "0.9.1"
   },
   "paths": {
     "/account/settings/linkedaccounts/": {},
@@ -3232,6 +3232,9 @@
             "schema": {
               "properties": {
                 "message": {
+                  "type": "string"
+                },
+                "run_number": {
                   "type": "string"
                 },
                 "status": {


### PR DESCRIPTION
Closes reanahub/reana-db#186
