### PR TITLE
openapi: add sharing parameters to `get_workflows`

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -6,8 +6,9 @@ The list of contributors in alphabetical order:
 - `Adelina Lintuluoto <https://orcid.org/0000-0002-0726-1452>`_
 - `Agisilaos Kounelis <https://orcid.org/0000-0001-9312-3189>`_
 - `Audrius Mecionis <https://orcid.org/0000-0002-3759-1663>`_
-- `Camila Diaz <https://orcid.org/0000-0001-5543-797X>`_
 - `Burt Holzman <https://orcid.org/0000-0001-5235-6314>`_
+- `Camila Diaz <https://orcid.org/0000-0001-5543-797X>`_
+- `Daan Rosendal <https://orcid.org/0000-0002-3447-9000>`_
 - `Daniel Prelipcean <https://orcid.org/0000-0002-4855-194X>`_
 - `Diego Rodriguez <https://orcid.org/0000-0003-0649-2002>`_
 - `Dinos Kousidis <https://orcid.org/0000-0002-4914-4289>`_

--- a/reana_commons/openapi_specifications/reana_server.json
+++ b/reana_commons/openapi_specifications/reana_server.json
@@ -2,7 +2,7 @@
   "info": {
     "description": "Submit workflows to be run on REANA Cloud",
     "title": "REANA Server",
-    "version": "0.9.1a3"
+    "version": "0.9.1"
   },
   "paths": {
     "/account/settings/linkedaccounts/": {},
@@ -3953,6 +3953,189 @@
           }
         },
         "summary": "Set status of a workflow."
+      }
+    },
+    "/api/workflows/{workflow_id_or_name}/unshare": {
+      "post": {
+        "description": "This resource unshares a workflow with another user. This resource is expecting a workflow UUID and some parameters.",
+        "operationId": "unshare_workflow",
+        "parameters": [
+          {
+            "description": "The API access_token of workflow owner.",
+            "in": "query",
+            "name": "access_token",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "Required. Workflow UUID or name.",
+            "in": "path",
+            "name": "workflow_id_or_name",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Required. User to unshare the workflow with.",
+            "in": "query",
+            "name": "user_email_to_unshare_with",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Request succeeded. The workflow has been unshared with the user.",
+            "examples": {
+              "application/json": {
+                "message": "The workflow has been unshared with the user.",
+                "workflow_id": "cdcf48b1-c2f3-4693-8230-b066e088c6ac",
+                "workflow_name": "mytest.1"
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                },
+                "workflow_id": {
+                  "type": "string"
+                },
+                "workflow_name": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "400": {
+            "description": "Request failed. The incoming data specification seems malformed.",
+            "examples": {
+              "application/json": {
+                "errors": [
+                  "Missing data for required field."
+                ],
+                "message": "Malformed request."
+              }
+            },
+            "schema": {
+              "properties": {
+                "errors": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "403": {
+            "description": "Request failed. User is not allowed to unshare the workflow.",
+            "examples": {
+              "application/json": {
+                "errors": [
+                  "User is not allowed to unshare the workflow."
+                ]
+              }
+            },
+            "schema": {
+              "properties": {
+                "errors": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "404": {
+            "description": "Request failed. Workflow does not exist or user does not exist.",
+            "examples": {
+              "application/json": {
+                "errors": [
+                  "Workflow cdcf48b1-c2f3-4693-8230-b066e088c6ac does not exist"
+                ],
+                "message": "Workflow cdcf48b1-c2f3-4693-8230-b066e088c6ac does not exist"
+              }
+            },
+            "schema": {
+              "properties": {
+                "errors": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "409": {
+            "description": "Request failed. The workflow is not shared with the user.",
+            "examples": {
+              "application/json": {
+                "errors": [
+                  "The workflow is not shared with the user."
+                ],
+                "message": "The workflow is not shared with the user."
+              }
+            },
+            "schema": {
+              "properties": {
+                "errors": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "500": {
+            "description": "Request failed. Internal controller error.",
+            "examples": {
+              "application/json": {
+                "errors": [
+                  "Internal controller error."
+                ],
+                "message": "Internal controller error."
+              }
+            },
+            "schema": {
+              "properties": {
+                "errors": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          }
+        },
+        "summary": "Unshare a workflow with another user."
       }
     },
     "/api/workflows/{workflow_id_or_name}/workspace": {

--- a/reana_commons/openapi_specifications/reana_server.json
+++ b/reana_commons/openapi_specifications/reana_server.json
@@ -1324,6 +1324,27 @@
             "name": "workflow_id_or_name",
             "required": false,
             "type": "string"
+          },
+          {
+            "description": "Optional flag to list all shared (owned and unowned) workflows.",
+            "in": "query",
+            "name": "shared",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "description": "Optional argument to list workflows shared by the specified user(s).",
+            "in": "query",
+            "name": "shared_by",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "Optional argument to list workflows shared with the specified user(s).",
+            "in": "query",
+            "name": "shared_with",
+            "required": false,
+            "type": "string"
           }
         ],
         "produces": [
@@ -1396,6 +1417,9 @@
                         "x-nullable": true
                       },
                       "name": {
+                        "type": "string"
+                      },
+                      "owner_email": {
                         "type": "string"
                       },
                       "progress": {
@@ -1486,6 +1510,9 @@
                         "type": "string"
                       },
                       "session_uri": {
+                        "type": "string"
+                      },
+                      "shared_with": {
                         "type": "string"
                       },
                       "size": {

--- a/reana_commons/openapi_specifications/reana_server.json
+++ b/reana_commons/openapi_specifications/reana_server.json
@@ -3163,6 +3163,139 @@
         "summary": "Share a workflow with another user."
       }
     },
+    "/api/workflows/{workflow_id_or_name}/share-status": {
+      "get": {
+        "description": "This resource returns the share status of a given workflow.",
+        "operationId": "get_workflow_share_status",
+        "parameters": [
+          {
+            "description": "The API access_token of workflow owner.",
+            "in": "query",
+            "name": "access_token",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "Required. Workflow UUID or name.",
+            "in": "path",
+            "name": "workflow_id_or_name",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Request succeeded. The response contains the share status of the workflow.",
+            "examples": {
+              "application/json": {
+                "shared_with": [
+                  {
+                    "user_email": "bob@example.org",
+                    "valid_until": "2022-11-24T23:59:59"
+                  }
+                ],
+                "workflow_id": "256b25f4-4cfb-4684-b7a8-73872ef455a1",
+                "workflow_name": "mytest.1"
+              }
+            },
+            "schema": {
+              "properties": {
+                "shared_with": {
+                  "items": {
+                    "properties": {
+                      "user_email": {
+                        "type": "string"
+                      },
+                      "valid_until": {
+                        "type": "string",
+                        "x-nullable": true
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "workflow_id": {
+                  "type": "string"
+                },
+                "workflow_name": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "401": {
+            "description": "Request failed. User not signed in.",
+            "examples": {
+              "application/json": {
+                "message": "User not signed in."
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "403": {
+            "description": "Request failed. Credentials are invalid or revoked.",
+            "examples": {
+              "application/json": {
+                "message": "Token not valid."
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "404": {
+            "description": "Request failed. Workflow does not exist.",
+            "examples": {
+              "application/json": {
+                "message": "Workflow mytest.1 does not exist."
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "500": {
+            "description": "Request failed. Internal server error.",
+            "examples": {
+              "application/json": {
+                "message": "Something went wrong."
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          }
+        },
+        "summary": "Get the share status of a workflow."
+      }
+    },
     "/api/workflows/{workflow_id_or_name}/specification": {
       "get": {
         "description": "This resource returns the REANA workflow specification used to start the workflow run. Resource is expecting a workflow UUID.",

--- a/reana_commons/openapi_specifications/reana_server.json
+++ b/reana_commons/openapi_specifications/reana_server.json
@@ -2972,6 +2972,197 @@
         "summary": "Get the retention rules of a workflow."
       }
     },
+    "/api/workflows/{workflow_id_or_name}/share": {
+      "post": {
+        "description": "This resource shares a workflow with another user. This resource is expecting a workflow UUID and some parameters.",
+        "operationId": "share_workflow",
+        "parameters": [
+          {
+            "description": "The API access_token of workflow owner.",
+            "in": "query",
+            "name": "access_token",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "Required. Workflow UUID or name.",
+            "in": "path",
+            "name": "workflow_id_or_name",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Required. User to share the workflow with.",
+            "in": "query",
+            "name": "user_email_to_share_with",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Optional. Message to include when sharing the workflow.",
+            "in": "query",
+            "name": "message",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "Optional. Date when access to the workflow will expire (format YYYY-MM-DD).",
+            "in": "query",
+            "name": "valid_until",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Request succeeded. The workflow has been shared with the user.",
+            "examples": {
+              "application/json": {
+                "message": "The workflow has been shared with the user.",
+                "workflow_id": "cdcf48b1-c2f3-4693-8230-b066e088c6ac",
+                "workflow_name": "mytest.1"
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                },
+                "workflow_id": {
+                  "type": "string"
+                },
+                "workflow_name": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "400": {
+            "description": "Request failed. The incoming data specification seems malformed.",
+            "examples": {
+              "application/json": {
+                "errors": [
+                  "Missing data for required field."
+                ],
+                "message": "Malformed request."
+              }
+            },
+            "schema": {
+              "properties": {
+                "errors": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "403": {
+            "description": "Request failed. User is not allowed to share the workflow.",
+            "examples": {
+              "application/json": {
+                "errors": [
+                  "User is not allowed to share the workflow."
+                ]
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "404": {
+            "description": "Request failed. Workflow does not exist or user does not exist.",
+            "examples": {
+              "application/json": {
+                "errors": [
+                  "Workflow cdcf48b1-c2f3-4693-8230-b066e088c6ac does not exist"
+                ],
+                "message": "Workflow cdcf48b1-c2f3-4693-8230-b066e088c6ac does not exist"
+              }
+            },
+            "schema": {
+              "properties": {
+                "errors": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "409": {
+            "description": "Request failed. The workflow is already shared with the user.",
+            "examples": {
+              "application/json": {
+                "errors": [
+                  "The workflow is already shared with the user."
+                ],
+                "message": "The workflow is already shared with the user."
+              }
+            },
+            "schema": {
+              "properties": {
+                "errors": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "500": {
+            "description": "Request failed. Internal controller error.",
+            "examples": {
+              "application/json": {
+                "errors": [
+                  "Internal controller error."
+                ],
+                "message": "Internal controller error."
+              }
+            },
+            "schema": {
+              "properties": {
+                "errors": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          }
+        },
+        "summary": "Share a workflow with another user."
+      }
+    },
     "/api/workflows/{workflow_id_or_name}/specification": {
       "get": {
         "description": "This resource returns the REANA workflow specification used to start the workflow run. Resource is expecting a workflow UUID.",

--- a/reana_commons/openapi_specifications/reana_workflow_controller.json
+++ b/reana_commons/openapi_specifications/reana_workflow_controller.json
@@ -993,6 +993,197 @@
         "summary": "Get the retention rules of a workflow."
       }
     },
+    "/api/workflows/{workflow_id_or_name}/share": {
+      "post": {
+        "description": "This resource allows to share a workflow with other users.",
+        "operationId": "share_workflow",
+        "parameters": [
+          {
+            "description": "Required. UUID of workflow owner.",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Required. Analysis UUID or name.",
+            "in": "path",
+            "name": "workflow_id_or_name",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Required. User to share the workflow with.",
+            "in": "query",
+            "name": "user_email_to_share_with",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Optional. Message to include when sharing the workflow.",
+            "in": "query",
+            "name": "message",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "Optional. Date when access to the workflow will expire (format YYYY-MM-DD).",
+            "in": "query",
+            "name": "valid_until",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Request succeeded. The workflow has been shared with the user.",
+            "examples": {
+              "application/json": {
+                "message": "The workflow has been shared with the user.",
+                "workflow_id": "cdcf48b1-c2f3-4693-8230-b066e088c6ac",
+                "workflow_name": "mytest.1"
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                },
+                "workflow_id": {
+                  "type": "string"
+                },
+                "workflow_name": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "400": {
+            "description": "Request failed. The incoming data specification seems malformed.",
+            "examples": {
+              "application/json": {
+                "errors": [
+                  "Missing data for required field."
+                ],
+                "message": "Malformed request."
+              }
+            },
+            "schema": {
+              "properties": {
+                "errors": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "403": {
+            "description": "Request failed. User is not allowed to share the workflow.",
+            "examples": {
+              "application/json": {
+                "errors": [
+                  "User is not allowed to share the workflow."
+                ]
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "404": {
+            "description": "Request failed. Workflow does not exist or user does not exist.",
+            "examples": {
+              "application/json": {
+                "errors": [
+                  "Workflow cdcf48b1-c2f3-4693-8230-b066e088c6ac does not exist"
+                ],
+                "message": "Workflow cdcf48b1-c2f3-4693-8230-b066e088c6ac does not exist"
+              }
+            },
+            "schema": {
+              "properties": {
+                "errors": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "409": {
+            "description": "Request failed. The workflow is already shared with the user.",
+            "examples": {
+              "application/json": {
+                "errors": [
+                  "The workflow is already shared with the user."
+                ],
+                "message": "The workflow is already shared with the user."
+              }
+            },
+            "schema": {
+              "properties": {
+                "errors": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "500": {
+            "description": "Request failed. Internal controller error.",
+            "examples": {
+              "application/json": {
+                "errors": [
+                  "Internal controller error."
+                ],
+                "message": "Internal controller error."
+              }
+            },
+            "schema": {
+              "properties": {
+                "errors": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          }
+        },
+        "summary": "Share a workflow with other users."
+      }
+    },
     "/api/workflows/{workflow_id_or_name}/status": {
       "get": {
         "description": "This resource reports the status of workflow.",

--- a/reana_commons/openapi_specifications/reana_workflow_controller.json
+++ b/reana_commons/openapi_specifications/reana_workflow_controller.json
@@ -2,7 +2,7 @@
   "info": {
     "description": "Submit and manage workflows",
     "title": "REANA Workflow Controller",
-    "version": "0.9.1a2"
+    "version": "0.9.1"
   },
   "paths": {
     "/api/workflows": {
@@ -1416,6 +1416,183 @@
           }
         },
         "summary": "Set workflow status."
+      }
+    },
+    "/api/workflows/{workflow_id_or_name}/unshare": {
+      "post": {
+        "description": "This resource allows to unshare a workflow with other users.",
+        "operationId": "unshare_workflow",
+        "parameters": [
+          {
+            "description": "Required. UUID of workflow owner.",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Required. Analysis UUID or name.",
+            "in": "path",
+            "name": "workflow_id_or_name",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Required. User to unshare the workflow with.",
+            "in": "query",
+            "name": "user_email_to_unshare_with",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Request succeeded. The workflow has been unshared with the user.",
+            "examples": {
+              "application/json": {
+                "message": "The workflow has been unsahred with the user.",
+                "workflow_id": "cdcf48b1-c2f3-4693-8230-b066e088c6ac",
+                "workflow_name": "mytest.1"
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                },
+                "workflow_id": {
+                  "type": "string"
+                },
+                "workflow_name": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "400": {
+            "description": "Request failed. The incoming data specification seems malformed.",
+            "examples": {
+              "application/json": {
+                "errors": [
+                  "Missing data for required field."
+                ],
+                "message": "Malformed request."
+              }
+            },
+            "schema": {
+              "properties": {
+                "errors": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "403": {
+            "description": "Request failed. User is not allowed to unshare the workflow.",
+            "examples": {
+              "application/json": {
+                "errors": [
+                  "User is not allowed to unshare the workflow."
+                ]
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "404": {
+            "description": "Request failed. Workflow does not exist or user does not exist.",
+            "examples": {
+              "application/json": {
+                "errors": [
+                  "Workflow cdcf48b1-c2f3-4693-8230-b066e088c6ac does not exist"
+                ],
+                "message": "Workflow cdcf48b1-c2f3-4693-8230-b066e088c6ac does not exist"
+              }
+            },
+            "schema": {
+              "properties": {
+                "errors": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "409": {
+            "description": "Request failed. The workflow is not shared with the user.",
+            "examples": {
+              "application/json": {
+                "errors": [
+                  "The workflow is not shared with the user."
+                ],
+                "message": "The workflow is not shared with the user."
+              }
+            },
+            "schema": {
+              "properties": {
+                "errors": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "500": {
+            "description": "Request failed. Internal controller error.",
+            "examples": {
+              "application/json": {
+                "errors": [
+                  "Internal controller error."
+                ],
+                "message": "Internal controller error."
+              }
+            },
+            "schema": {
+              "properties": {
+                "errors": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          }
+        },
+        "summary": "Unshare a workflow with other users."
       }
     },
     "/api/workflows/{workflow_id_or_name}/workspace": {

--- a/reana_commons/openapi_specifications/reana_workflow_controller.json
+++ b/reana_commons/openapi_specifications/reana_workflow_controller.json
@@ -1184,6 +1184,139 @@
         "summary": "Share a workflow with other users."
       }
     },
+    "/api/workflows/{workflow_id_or_name}/share-status": {
+      "get": {
+        "description": "This resource returns the share status of a given workflow.",
+        "operationId": "get_workflow_share_status",
+        "parameters": [
+          {
+            "description": "Required. UUID of workflow owner.",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Required. Workflow UUID or name.",
+            "in": "path",
+            "name": "workflow_id_or_name",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Request succeeded. The response contains the share status of the workflow.",
+            "examples": {
+              "application/json": {
+                "shared_with": [
+                  {
+                    "user_email": "bob@example.org",
+                    "valid_until": "2022-11-24T23:59:59"
+                  }
+                ],
+                "workflow_id": "256b25f4-4cfb-4684-b7a8-73872ef455a1",
+                "workflow_name": "mytest.1"
+              }
+            },
+            "schema": {
+              "properties": {
+                "shared_with": {
+                  "items": {
+                    "properties": {
+                      "user_email": {
+                        "type": "string"
+                      },
+                      "valid_until": {
+                        "type": "string",
+                        "x-nullable": true
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "workflow_id": {
+                  "type": "string"
+                },
+                "workflow_name": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "401": {
+            "description": "Request failed. User not signed in.",
+            "examples": {
+              "application/json": {
+                "message": "User not signed in."
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "403": {
+            "description": "Request failed. Credentials are invalid or revoked.",
+            "examples": {
+              "application/json": {
+                "message": "Token not valid."
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "404": {
+            "description": "Request failed. Workflow does not exist.",
+            "examples": {
+              "application/json": {
+                "message": "Workflow mytest.1 does not exist."
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "500": {
+            "description": "Request failed. Internal server error.",
+            "examples": {
+              "application/json": {
+                "message": "Something went wrong."
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          }
+        },
+        "summary": "Get the share status of a workflow."
+      }
+    },
     "/api/workflows/{workflow_id_or_name}/status": {
       "get": {
         "description": "This resource reports the status of workflow.",

--- a/reana_commons/openapi_specifications/reana_workflow_controller.json
+++ b/reana_commons/openapi_specifications/reana_workflow_controller.json
@@ -89,6 +89,27 @@
             "name": "workflow_id_or_name",
             "required": false,
             "type": "string"
+          },
+          {
+            "description": "Optional flag to list all shared (owned and unowned) workflows.",
+            "in": "query",
+            "name": "shared",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "description": "Optional argument to list workflows shared by the specified user(s).",
+            "in": "query",
+            "name": "shared_by",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "Optional argument to list workflows shared with the specified user(s).",
+            "in": "query",
+            "name": "shared_with",
+            "required": false,
+            "type": "string"
           }
         ],
         "produces": [
@@ -167,8 +188,14 @@
                       "name": {
                         "type": "string"
                       },
+                      "owner_email": {
+                        "type": "string"
+                      },
                       "progress": {
                         "type": "object"
+                      },
+                      "shared_with": {
+                        "type": "string"
                       },
                       "size": {
                         "properties": {


### PR DESCRIPTION
Adds new `shared`, `shared_with` and `shared_by` parameters to the
`get_workflows` endpoint to retrieve workflows along with their sharing
information.

Closes reanahub/reana-client#687
