### PR TITLE
fix(snakemake): update to v7.32.4 to make Python 3.11 clients compatible

### DIFF
--- a/reana_commons/config.py
+++ b/reana_commons/config.py
@@ -440,7 +440,7 @@ REANA_COMPUTE_BACKENDS = {
 REANA_WORKFLOW_ENGINES = ["yadage", "cwl", "serial", "snakemake"]
 """Available workflow engines."""
 
-REANA_DEFAULT_SNAKEMAKE_ENV_IMAGE = "docker.io/snakemake/snakemake:v6.8.0"
+REANA_DEFAULT_SNAKEMAKE_ENV_IMAGE = "docker.io/snakemake/snakemake:v7.32.4"
 """Snakemake default job environment image."""
 
 REANA_JOB_CONTROLLER_CONNECTION_CHECK_SLEEP = float(

--- a/setup.py
+++ b/setup.py
@@ -35,13 +35,13 @@ extras_require = {
     "yadage": ["adage~=0.10.1", "yadage~=0.20.1", "yadage-schemas~=0.10.6"],
     "cwl": ["cwltool==3.1.20210628163208"],
     "snakemake": [
-        "snakemake==6.8.0 ; python_version<'3.12'",
-        "snakemake==7.9.0 ; python_version>='3.12'",
+        "snakemake==6.15.5 ; python_version<'3.7'",  # Snakemake v7 requires Python 3.7+
+        "snakemake==7.32.4 ; python_version>='3.7'",
         "tabulate<0.9",
     ],
     "snakemake_reports": [
-        "snakemake[reports]==6.8.0 ; python_version<'3.12'",
-        "snakemake[reports]==7.9.0 ; python_version>='3.12'",
+        "snakemake==6.15.5 ; python_version<'3.7'",
+        "snakemake==7.32.4 ; python_version>='3.7'",
         "pygraphviz<1.8",
         "tabulate<0.9",  # tabulate 0.9 crashes snakemake, more info: https://github.com/snakemake/snakemake/issues/1899
     ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ rule all:
         "results/foo.txt",
         "results/bar.txt",
         "results/baz.txt"
+    default_target: True
 
 rule foo:
     input:

--- a/tests/test_snakemake.py
+++ b/tests/test_snakemake.py
@@ -17,10 +17,6 @@ from reana_commons.snakemake import snakemake_load
 
 def test_snakemake_load(tmpdir, dummy_snakefile):
     """Test that Snakemake metadata is loaded properly."""
-    if sys.version_info.major == 3 and sys.version_info.minor in (11, 12):
-        pytest.xfail(
-            "Snakemake features of reana-client are not supported on Python 3.11"
-        )
     workdir = tmpdir.mkdir("sub")
     # write Snakefile
     p = workdir.join("Snakefile")


### PR DESCRIPTION
Update Snakemake version to v7.32.4 (latest one before v8 refactoring),
to support newer features and resolve problems for clients using Python 3.11.

- `reana_commons/config.py`: update default Snakemake environment image.
- `reana_commons/snakemake.py`: modify `first_rule` directive to
  `default_target` directive to adhere to the changes made in
  [snakemake/snakemake!638ec1a](https://github.com/snakemake/snakemake/tree/638ec1a983741cd7ba8faaf1a9dc76ae43d012e5).
- `setup.py`: adjust Snakemake version in the dependencies.

Closes: reanahub/reana-client#655.
Closes: reanahub/reana-workflow-engine-snakemake#31.

---

Note that, even though the external Snakemake API did not change, quite a few things
are different internally from v6.8.0 to v7.32.4, so proper testing is needed.
Also note that bigger efforts in improving the way in which Snakemake and REANA
interact are probably better suited when upgrading to Snakemake v8 and use a plugin-based
approach.