### PR TITLE
build(python): change extra names to comply with PEP 685 (#446)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ extras_require = {
         "tabulate<0.9",
         "pulp>=2.7.0,<2.8.0",
     ],
-    "snakemake_reports": [
+    "snakemake-reports": [
         "snakemake==6.15.5 ; python_version<'3.7'",
         "snakemake==7.32.4 ; python_version>='3.7'",
         "pygraphviz<1.8",
@@ -49,6 +49,9 @@ extras_require = {
         "pulp>=2.7.0,<2.8.0",
     ],
 }
+
+# backwards compatibility with extras before PEP 685
+extras_require["snakemake_reports"] = extras_require["snakemake-reports"]
 
 extras_require["all"] = []
 for key, reqs in extras_require.items():


### PR DESCRIPTION
Since pip>=23.3.0, non-normalised extra names are ignored, so
`snakemake_reports` is changed to `snakemake-reports`. The former name
is kept for backward compatibility with older versions of pip.

Before

```console
$ pip install --upgrade pip
$ pip install '.[snakemake-reports]' | grep WARN
WARNING: reana-commons 0.9.7 does not provide the extra 'snakemake-reports'
$ pip install '.[snakemake_reports]' | grep WARN
WARNING: reana-commons 0.9.7 does not provide the extra 'snakemake-reports'
```

After

```console
$ pip install --upgrade pip
$ pip install '.[snakemake_reports]' | grep WARN
$ pip install '.[snakemake-reports]' | grep WARN
```