### PR TITLE
perf/fix(kerberos): kerberos ticket renewal improvements (#454)

### DIFF
--- a/reana_commons/config.py
+++ b/reana_commons/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2018, 2019, 2020, 2021, 2022, 2023 CERN.
+# Copyright (C) 2018, 2019, 2020, 2021, 2022, 2023, 2024 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -461,7 +461,7 @@ COMMAND_DANGEROUS_OPERATIONS = ["sudo ", "cd /"]
 # Kerberos configurations
 
 KRB5_CONTAINER_IMAGE = os.getenv(
-    "KRB5_CONTAINER_IMAGE", "docker.io/reanahub/reana-auth-krb5:1.0.1"
+    "KRB5_CONTAINER_IMAGE", "docker.io/reanahub/reana-auth-krb5:1.0.3"
 )
 """Default docker image of KRB5 sidecar container."""
 
@@ -470,10 +470,6 @@ KRB5_INIT_CONTAINER_NAME = "krb5-init"
 
 KRB5_RENEW_CONTAINER_NAME = "krb5-renew"
 """Name of KRB5 sidecar container used for ticket renewal."""
-
-KRB5_STATUS_FILE_LOCATION = "/krb5_cache/status_file"
-"""Status file path used to terminate KRB5 renew container when the main
-job finishes."""
 
 KRB5_STATUS_FILE_CHECK_INTERVAL = 15
 """Time interval in seconds between checks to the status file."""
@@ -488,6 +484,16 @@ should match `default_ccache_name` in krb5.conf.
 
 KRB5_TOKEN_CACHE_FILENAME = "krb5_{}"
 """Name of the Kerberos token cache file."""
+
+KRB5_STATUS_FILENAME = "status_file"
+"""Name of status file used to terminate KRB5 renew container when the main
+job finishes."""
+
+KRB5_STATUS_FILE_LOCATION = os.path.join(
+    KRB5_TOKEN_CACHE_LOCATION, KRB5_STATUS_FILENAME
+)
+"""Status file path used to terminate KRB5 renew container when the main
+job finishes."""
 
 KRB5_CONFIGMAP_NAME = os.getenv(
     "REANA_KRB5_CONFIGMAP_NAME", f"{REANA_COMPONENT_PREFIX}-krb5-conf"

--- a/reana_commons/k8s/kerberos.py
+++ b/reana_commons/k8s/kerberos.py
@@ -126,6 +126,12 @@ def get_kerberos_k8s_config(
         "volumeMounts": [secrets_volume_mount] + volume_mounts,
         "env": env,
         "securityContext": {"runAsUser": kubernetes_uid},
+        "lifecycle": {
+            # make sure we stop the sidecar container when the pod is stopped,
+            # for example when the run-batch pod is terminated by reana-workflow-controller
+            # after the workflow finishes (either successfully or with an error)
+            "preStop": {"exec": {"command": ["touch", KRB5_STATUS_FILE_LOCATION]}}
+        },
     }
 
     return KerberosConfig(

--- a/reana_commons/k8s/kerberos.py
+++ b/reana_commons/k8s/kerberos.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2022 CERN.
+# Copyright (C) 2022, 2024 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -115,7 +115,10 @@ def get_kerberos_k8s_config(
                 f"while ! test -f {KRB5_STATUS_FILE_LOCATION}; do "
                 f"if [ $SECONDS -ge {KRB5_TICKET_RENEW_INTERVAL} ]; then "
                 'echo "Renewing Kerberos ticket: $(date)"; kinit -R; SECONDS=0; fi; '
-                f"sleep {KRB5_STATUS_FILE_CHECK_INTERVAL}; done"
+                # wait until status file is created or for a given timeout, whichever comes first
+                f"inotifywait --quiet --format 'Detected job status change' --timeout {KRB5_STATUS_FILE_CHECK_INTERVAL} --event create {KRB5_TOKEN_CACHE_LOCATION}; "
+                "done; "
+                "echo 'Stopping Kerberos ticket renewal sidecar'"
             )
         ],
         "name": KRB5_RENEW_CONTAINER_NAME,


### PR DESCRIPTION
- perf(kerberos): stop ticket renewal immediately (#454)
  
  Use `inotifywait` instead of `sleep` when waiting for the status file to
  be created, so that the pod stops immediately after the file creation.
  
  Closes https://github.com/reanahub/reana-job-controller/issues/450
- fix(kerberos): stop ticket renewal when pod is terminated (#453)
  
  Closes https://github.com/reanahub/reana-job-controller/issues/449
