### PR TITLE
deprecations setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+# This file is part of REANA.
+# Copyright (C) 2024 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -55,7 +55,7 @@ check_sphinx () {
 }
 
 check_pytest () {
-    python setup.py test
+    pytest
 }
 
 check_all () {

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,9 +4,6 @@
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-[aliases]
-test = pytest
-
 [build_sphinx]
 source-dir = docs/
 build-dir = docs/_build

--- a/setup.py
+++ b/setup.py
@@ -59,10 +59,6 @@ for key, reqs in extras_require.items():
         continue
     extras_require["all"].extend(reqs)
 
-setup_requires = [
-    "pytest-runner>=2.7",
-]
-
 install_requires = [
     "bravado>=10.2,<10.4",
     # bravado-core 6.1.1 breaks compatibility with jsonschema<4.9.0
@@ -105,7 +101,6 @@ setup(
     python_requires=">=3.8",
     install_requires=install_requires,
     extras_require=extras_require,
-    setup_requires=setup_requires,
     tests_require=tests_require,
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -18,18 +18,15 @@ from setuptools import find_packages, setup
 readme = open("README.md").read()
 history = open("CHANGELOG.md").read()
 
-tests_require = [
-    "pytest-reana>=0.95.0a2,<0.96.0",
-]
-
-
 extras_require = {
     "docs": [
         "myst-parser",
         "Sphinx>=1.5.1",
         "sphinx-rtd-theme>=0.1.9",
     ],
-    "tests": tests_require,
+    "tests": [
+        "pytest-reana>=0.95.0a2,<0.96.0",
+    ],
     "kubernetes": [
         "kubernetes>=22.0.0,<23.0.0",
     ],
@@ -101,7 +98,6 @@ setup(
     python_requires=">=3.8",
     install_requires=install_requires,
     extras_require=extras_require,
-    tests_require=tests_require,
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Environment :: Web Environment",

--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,9 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 
 [tox]
-envlist = py36, py37, py38, py39, py310, py311, py312
+envlist = py38, py39, py310, py311, py312
 
 [testenv]
 deps = pytest
        pytest-cov
-commands = {envpython} setup.py test
+commands = pytest {posargs}


### PR DESCRIPTION
- **ci(pytest): invoke `pytest` directly instead of `setup.py test` (#466)**
- **build(python): remove deprecated `pytest-runner` (#466)**
- **build(python): use optional deps instead of `tests_require` (#466)**
- **build(python): add minimal `pyproject.toml` (#466)**


Closes https://github.com/reanahub/reana/issues/814