### PR TITLE
feat(redis-cache): add module (#469)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -14,6 +14,7 @@ The list of contributors in alphabetical order:
 - [Dinos Kousidis](https://orcid.org/0000-0002-4914-4289)
 - [Giuseppe Steduto](https://orcid.org/0009-0002-1258-8553)
 - [Jan Okraska](https://orcid.org/0000-0002-1416-3244)
+- [Jelizaveta Lemeševa](https://orcid.org/0009-0003-6606-9270)
 - [Kenyi Hurtado-Anampa](https://orcid.org/0000-0002-9779-3566)
 - [Leticia Wanderley](https://orcid.org/0000-0003-4649-6630)
 - [Marco Donadoni](https://orcid.org/0000-0003-2922-5505)

--- a/reana_commons/config.py
+++ b/reana_commons/config.py
@@ -499,3 +499,6 @@ KRB5_CONFIGMAP_NAME = os.getenv(
     "REANA_KRB5_CONFIGMAP_NAME", f"{REANA_COMPONENT_PREFIX}-krb5-conf"
 )
 """Kerberos configMap name."""
+
+REDIS_CACHE_PORT = 6379
+"""Redis cache port."""

--- a/reana_commons/redis_cache.py
+++ b/reana_commons/redis_cache.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2024 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""REANA-commons Redis cache."""
+
+from redis import StrictRedis
+from redis_cache import RedisCache
+
+from reana_commons.config import (
+    REANA_INFRASTRUCTURE_COMPONENTS_HOSTNAMES,
+    REDIS_CACHE_PORT,
+)
+
+redis_cache = RedisCache(
+    redis_client=StrictRedis(
+        host=REANA_INFRASTRUCTURE_COMPONENTS_HOSTNAMES["cache"],
+        port=REDIS_CACHE_PORT,
+        decode_responses=True,
+    )
+)

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,9 @@ extras_require = {
         "snakemake[reports] @ git+https://github.com/mdonadoni/snakemake.git@cea31624976989ad0645eb2e1751260d32259506",  # branch `7.32.4-python3.12`
         "pulp>=2.7.0,<2.8.0",
     ],
+    "redis-cache": [
+        "python-redis-cache>=4.0.0,<4.1.0",
+    ],
 }
 
 # backwards compatibility with extras before PEP 685


### PR DESCRIPTION
Add `redis-cache` extra to be used in `reana-workflow-controller` API to cache workflow/job logs.

It will be possible to install it on demand as not all components need it. To use it, add annotation to a function, example in [docs](https://pypi.org/project/python-redis-cache/).

Also add myself to `AUTHORS.md`.