### PR TITLE
build(python): add support for Python 3.13 (#472)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - name: Checkout

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -16,6 +16,7 @@ The list of contributors in alphabetical order:
 - [Dinos Kousidis](https://orcid.org/0000-0002-4914-4289)
 - [Giuseppe Steduto](https://orcid.org/0009-0002-1258-8553)
 - [Jan Okraska](https://orcid.org/0000-0002-1416-3244)
+- [Jelizaveta Lemeševa](https://orcid.org/0009-0003-6606-9270)
 - [Kenyi Hurtado-Anampa](https://orcid.org/0000-0002-9779-3566)
 - [Leticia Wanderley](https://orcid.org/0000-0003-4649-6630)
 - [Marco Donadoni](https://orcid.org/0000-0003-2922-5505)

--- a/setup.py
+++ b/setup.py
@@ -116,6 +116,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python",
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ envlist =
     py310
     py311
     py312
+    py313
 
 [testenv]
 deps =


### PR DESCRIPTION
Closes https://github.com/reanahub/reana/issues/837

Add support for Python 3.13.