### PR TITLE
ci(actions): pin setuptools 70 (#479)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
+          pip install --upgrade pip 'setuptools<71' py
           pip install -e .[all]
 
       - name: Run Sphinx documentation with doctests
@@ -161,6 +162,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
+          pip install --upgrade pip 'setuptools<71' py
           pip install twine wheel
           pip install -e .[all]
 


### PR DESCRIPTION
Pin `setuptools` to the maximum version of 70 to allow working on Ubuntu
20.04 LTS based environments. (New versions of `setuptools` are not
compatible.)

Note that this fix is necessary only for the `maint-0.9` branches and
the REANA 0.9 release series. In `master` we have switched to Ubuntu
24.04 LTS based environments and Python 3.12 and no pinning is necessary
there.
