### PR TITLE
build(python): add support for Python 3.13 (#480)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
       - name: Checkout

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -14,6 +14,7 @@ The list of contributors in alphabetical order:
 - [Dinos Kousidis](https://orcid.org/0000-0002-4914-4289)
 - [Giuseppe Steduto](https://orcid.org/0009-0002-1258-8553)
 - [Jan Okraska](https://orcid.org/0000-0002-1416-3244)
+- [Jelizaveta Lemeševa](https://orcid.org/0009-0003-6606-9270)
 - [Kenyi Hurtado-Anampa](https://orcid.org/0000-0002-9779-3566)
 - [Leticia Wanderley](https://orcid.org/0000-0003-4649-6630)
 - [Manuel Giffels](https://orcid.org/0000-0003-0193-3032)

--- a/setup.py
+++ b/setup.py
@@ -123,6 +123,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python",
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,15 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 
 [tox]
-envlist = py36, py37, py38, py39, py310, py311, py312
+envlist =
+    py36
+    py37
+    py38
+    py39
+    py310
+    py311
+    py312
+    py313
 
 [testenv]
 deps = pytest


### PR DESCRIPTION
Closes reanahub/reana#837

Cherry-pick of #472