### PR TITLE
Add Voms_proxy and Rucio under resources in reana.yaml schema

### DIFF
--- a/reana_commons/validation/schemas/reana_analysis_schema.json
+++ b/reana_commons/validation/schemas/reana_analysis_schema.json
@@ -109,6 +109,16 @@
               "type": "boolean",
               "title": "Kerberos authentication for the whole workflow."
             },
+            "voms_proxy": {
+              "$id": "/properties/workflow/properties/resources/properties/voms_proxy",
+              "type": "boolean",
+              "title": "VOMS proxy authentication for the whole workflow."
+            },
+            "rucio": {
+              "id": "/properties/workflow/properties/resources/properties/rucio",
+              "type": "boolean",
+              "title": "Rucio integration"
+            },
             "dask": {
               "$id": "/properties/workflow/properties/resources/properties/dask",
               "type": "object",

--- a/reana_commons/version.py
+++ b/reana_commons/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.95.0a7"
+__version__ = "0.95.0a8"


### PR DESCRIPTION
Following Dask integration into REANA, it became necessary for Dask clusters to be aware of if voms_proxy or rucio is needed for the whole workflow. Parsing each step in `reana.yaml` is not desirable, hence we add voms_proxy and rucio under global resources definition.