### PR TITLE
feat(openapi): add fields for number of threads for Dask workers 

### DIFF
--- a/reana_commons/openapi_specifications/reana_server.json
+++ b/reana_commons/openapi_specifications/reana_server.json
@@ -2,7 +2,7 @@
   "info": {
     "description": "Submit workflows to be run on REANA Cloud",
     "title": "REANA Server",
-    "version": "0.95.0a1"
+    "version": "0.95.0a2"
   },
   "paths": {
     "/account/settings/linkedaccounts/": {},
@@ -449,6 +449,10 @@
                   "title": "The amount of memory used by default by a single Dask worker",
                   "value": "2Gi"
                 },
+                "dask_cluster_default_single_worker_threads": {
+                  "title": "The number of threads used by default by a single Dask worker",
+                  "value": "4"
+                },
                 "dask_cluster_max_memory_limit": {
                   "title": "The maximum memory limit for Dask clusters created by users",
                   "value": "16Gi"
@@ -460,6 +464,10 @@
                 "dask_cluster_max_single_worker_memory": {
                   "title": "The maximum amount of memory that users can ask for the single Dask worker",
                   "value": "8Gi"
+                },
+                "dask_cluster_max_single_worker_threads": {
+                  "title": "The maximum number of threads that users can ask for the single Dask worker",
+                  "value": "8"
                 },
                 "dask_enabled": {
                   "title": "Dask workflows allowed in the cluster",
@@ -606,6 +614,17 @@
                   },
                   "type": "object"
                 },
+                "dask_cluster_default_single_worker_threads": {
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
                 "dask_cluster_max_memory_limit": {
                   "properties": {
                     "title": {
@@ -629,6 +648,17 @@
                   "type": "object"
                 },
                 "dask_cluster_max_single_worker_memory": {
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "dask_cluster_max_single_worker_threads": {
                   "properties": {
                     "title": {
                       "type": "string"

--- a/reana_commons/validation/schemas/reana_analysis_schema.json
+++ b/reana_commons/validation/schemas/reana_analysis_schema.json
@@ -124,19 +124,24 @@
               "type": "object",
               "title": "Information about Dask cluster requested for the analysis.",
               "properties": {
-                "image": {
-                  "type": "string",
-                  "description": "Container image to be used by Dask scheduler and workers."
-                },
-                "number_of_workers": {
-                  "type": "number",
-                  "description": "Requested number of Dask workers."
-                },
-                "single_worker_memory": {
-                  "type": "string",
-                  "description": "Requested memory for one Dask worker.",
-                  "pattern": "^[1-9][0-9]*(Ei|Pi|Ti|Gi|Mi|Ki|E|P|T|G|M|K)$"
-                }
+              "image": {
+                "type": "string",
+                "description": "Container image to be used by Dask scheduler and workers.",
+                "pattern": "^(?:[a-zA-Z0-9.-]+(?:\\.[a-zA-Z0-9.-]+)+(?::[0-9]+)?/)?[a-zA-Z0-9._-]+(?:/[a-zA-Z0-9._-]+)*(?::[a-zA-Z0-9._-]+)?(?:@sha256:[a-f0-9]{64})?$"
+              },
+              "number_of_workers": {
+                "type": "integer",
+                "description": "Requested number of Dask workers."
+              },
+              "single_worker_memory": {
+                "type": "string",
+                "description": "Requested memory for one Dask worker.",
+                "pattern": "^[1-9][0-9]*(Ei|Pi|Ti|Gi|Mi|Ki|E|P|T|G|M|K)$"
+              },
+              "single_worker_threads": {
+                "type": "integer",
+                "description": "Requested number of threads for one Dask worker."
+              }
               },
               "required": ["image"]
             }

--- a/reana_commons/version.py
+++ b/reana_commons/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.95.0a8"
+__version__ = "0.95.0a9"


### PR DESCRIPTION
Following the integration of Dask into REANA and discussions with several REANA users, we identified the need to make the number of threads configurable.

This commit introduces an additional field to allow users to specify the number of threads. The field is optional, similar to other Dask parameters, except for the image field.

The OpenAPI specification for the `api/info` command has been updated to include the default and maximum number of threads option for Dask workers.

Closes reanahub/reana#874