### PR TITLE
feat(openapi): add K8s resource requests and limits in reana.yaml

### DIFF
--- a/reana_commons/api_client.py
+++ b/reana_commons/api_client.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2018, 2019, 2020, 2021, 2022 CERN.
+# Copyright (C) 2018, 2019, 2020, 2021, 2022, 2025 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -99,6 +99,9 @@ class JobControllerAPIClient(BaseAPIClient):
         compute_backend=None,
         kerberos=False,
         kubernetes_uid=None,
+        kubernetes_cpu_request=None,
+        kubernetes_cpu_limit=None,
+        kubernetes_memory_request=None,
         kubernetes_memory_limit=None,
         unpacked_img=False,
         voms_proxy=False,
@@ -165,6 +168,15 @@ class JobControllerAPIClient(BaseAPIClient):
 
         if kubernetes_uid:
             job_spec["kubernetes_uid"] = kubernetes_uid
+
+        if kubernetes_cpu_request:
+            job_spec["kubernetes_cpu_request"] = kubernetes_cpu_request
+
+        if kubernetes_cpu_limit:
+            job_spec["kubernetes_cpu_limit"] = kubernetes_cpu_limit
+
+        if kubernetes_memory_request:
+            job_spec["kubernetes_memory_request"] = kubernetes_memory_request
 
         if kubernetes_memory_limit:
             job_spec["kubernetes_memory_limit"] = kubernetes_memory_limit

--- a/reana_commons/config.py
+++ b/reana_commons/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2018, 2019, 2020, 2021, 2022, 2023, 2024 CERN.
+# Copyright (C) 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -419,6 +419,9 @@ KUBERNETES_MEMORY_FORMAT = r"(?:(?P<value_bytes>\d+)|(?P<value_unit>(\d+[.])?\d+
     "".join(KUBERNETES_MEMORY_UNITS)
 )
 """Kubernetes valid memory format regular expression e.g. Ki, M, Gi, G, etc."""
+
+KUBERNETES_CPU_FORMAT = r"^(?P<value_millicpu>[1-9]\d*)m$|^(?P<value_cpu>(0*[1-9]\d*(\.\d+)?|0*\.\d*[1-9]\d*))$"
+"""Kubernetes valid CPU format regex. Supports formats such as "0.1" (or "100m"), "0.9" (or "900m"). Values must be greater than 0."""
 
 statuses = os.getenv("REANA_RUNTIME_KUBERNETES_KEEP_ALIVE_JOBS_WITH_STATUSES", [])
 REANA_RUNTIME_KUBERNETES_KEEP_ALIVE_JOBS_WITH_STATUSES = (

--- a/reana_commons/errors.py
+++ b/reana_commons/errors.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2018, 2019, 2020, 2021, 2022 CERN.
+# Copyright (C) 2018, 2019, 2020, 2021, 2022, 2025 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -83,6 +83,30 @@ class REANAKubernetesMemoryLimitExceeded(Exception):
 
     def __init__(self, message):
         """Initialize REANAKubernetesMemoryLimitExceeded exception."""
+        self.message = message
+
+
+class REANAKubernetesWrongCPUFormat(Exception):
+    """Kubernetes CPU value has wrong format."""
+
+    def __init__(self, message):
+        """Initialize REANAKubernetesWrongCPUFormat exception."""
+        self.message = message
+
+
+class REANAKubernetesCPULimitExceeded(Exception):
+    """Kubernetes CPU value exceed max limit."""
+
+    def __init__(self, message):
+        """Initialize REANAKubernetesCPULimitExceeded exception."""
+        self.message = message
+
+
+class REANAKubernetesRequestExceedsLimit(Exception):
+    """Kubernetes resource request exceeds its corresponding limit."""
+
+    def __init__(self, message):
+        """Initialize REANAKubernetesRequestExceedsLimit exception."""
         self.message = message
 
 

--- a/reana_commons/job_utils.py
+++ b/reana_commons/job_utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2021 CERN.
+# Copyright (C) 2021, 2025 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -10,7 +10,7 @@
 import base64
 import re
 
-from reana_commons.config import KUBERNETES_MEMORY_FORMAT
+from reana_commons.config import KUBERNETES_CPU_FORMAT, KUBERNETES_MEMORY_FORMAT
 from reana_commons.errors import REANAKubernetesWrongMemoryFormat
 
 
@@ -22,6 +22,11 @@ def serialise_job_command(command):
 def deserialise_job_command(command):
     """Deserialise job commands received through REST API."""
     return base64.b64decode(command).decode("utf-8")
+
+
+def validate_kubernetes_cpu(memory):
+    """Verify that provided value matches the Kubernetes cpu format."""
+    return re.match(KUBERNETES_CPU_FORMAT, memory) is not None
 
 
 def validate_kubernetes_memory(memory):
@@ -53,3 +58,17 @@ def kubernetes_memory_to_bytes(memory):
     }
 
     return value * multiplier[unit][power]
+
+
+def kubernetes_cpu_to_millicores(cpu):
+    """Convert Kubernetes CPU format to millicores (mCPU)."""
+    match = re.match(KUBERNETES_CPU_FORMAT, str(cpu))
+    if not match:
+        raise ValueError(f"Kubernetes CPU value '{cpu}' has wrong format.")
+
+    cpu_values = match.groupdict()
+
+    if cpu_values.get("value_millicpu"):
+        return int(cpu_values.get("value_millicpu"))
+    else:
+        return int(float(cpu_values.get("value_cpu")) * 1000)

--- a/reana_commons/openapi_specifications/reana_server.json
+++ b/reana_commons/openapi_specifications/reana_server.json
@@ -2,7 +2,7 @@
   "info": {
     "description": "Submit workflows to be run on REANA Cloud",
     "title": "REANA Server",
-    "version": "0.9.3"
+    "version": "0.9.4"
   },
   "paths": {
     "/account/settings/linkedaccounts/": {},
@@ -366,13 +366,37 @@
                   "title": "Default workspace",
                   "value": "/usr/share"
                 },
+                "kubernetes_cpu_limit": {
+                  "title": "Default CPU limit for Kubernetes jobs",
+                  "value": "2"
+                },
+                "kubernetes_cpu_request": {
+                  "title": "Default CPU request for Kubernetes jobs",
+                  "value": "1"
+                },
+                "kubernetes_max_cpu_limit": {
+                  "title": "Maximum allowed CPU limit for Kubernetes jobs",
+                  "value": "4"
+                },
+                "kubernetes_max_cpu_request": {
+                  "title": "Maximum allowed CPU request for Kubernetes jobs",
+                  "value": "2"
+                },
                 "kubernetes_max_memory_limit": {
                   "title": "Maximum allowed memory limit for Kubernetes jobs",
-                  "value": "10Gi"
+                  "value": "10Gi\""
+                },
+                "kubernetes_max_memory_request": {
+                  "title": "Maximum allowed memory request for Kubernetes jobs",
+                  "value": "5Gi"
                 },
                 "kubernetes_memory_limit": {
                   "title": "Default memory limit for Kubernetes jobs",
                   "value": "3Gi"
+                },
+                "kubernetes_memory_request": {
+                  "title": "Default memory request for Kubernetes jobs",
+                  "value": "1Gi"
                 },
                 "maximum_kubernetes_jobs_timeout": {
                   "title": "Maximum timeout for Kubernetes jobs",
@@ -408,6 +432,28 @@
                   },
                   "type": "object"
                 },
+                "default_kubernetes_cpu_limit": {
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "default_kubernetes_cpu_request": {
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
                 "default_kubernetes_jobs_timeout": {
                   "properties": {
                     "title": {
@@ -430,6 +476,17 @@
                   },
                   "type": "object"
                 },
+                "default_kubernetes_memory_request": {
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
                 "default_workspace": {
                   "properties": {
                     "title": {
@@ -441,7 +498,43 @@
                   },
                   "type": "object"
                 },
+                "kubernetes_max_cpu_limit": {
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string",
+                      "x-nullable": true
+                    }
+                  },
+                  "type": "object"
+                },
+                "kubernetes_max_cpu_request": {
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string",
+                      "x-nullable": true
+                    }
+                  },
+                  "type": "object"
+                },
                 "kubernetes_max_memory_limit": {
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string",
+                      "x-nullable": true
+                    }
+                  },
+                  "type": "object"
+                },
+                "kubernetes_max_memory_request": {
                   "properties": {
                     "title": {
                       "type": "string"

--- a/reana_commons/validation/schemas/reana_analysis_schema.json
+++ b/reana_commons/validation/schemas/reana_analysis_schema.json
@@ -275,6 +275,21 @@
                       "title": "Kubernetes job timeout",
                       "description": "Maximum time for the step to run (number of seconds)"
                     },
+                    "kubernetes_cpu_request": {
+                      "type": "string",
+                      "title": "Kubernetes CPU request",
+                      "description": "Kubernetes CPU request (e.g. 1 - read more about the expected CPU values on the official Kubernetes documentation: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu)"
+                    },
+                    "kubernetes_cpu_limit": {
+                      "type": "string",
+                      "title": "Kubernetes CPU limit",
+                      "description": "Kubernetes CPU limit (e.g. 2 - read more about the expected CPU values on the official Kubernetes documentation: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu)"
+                    },
+                    "kubernetes_memory_request": {
+                      "type": "string",
+                      "title": "Kubernetes memory request",
+                      "description": "Kubernetes memory request (e.g. 128Mi - read more about the expected memory values on the official Kubernetes documentation: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory)"
+                    },
                     "kubernetes_memory_limit": {
                       "type": "string",
                       "title": "Kubernetes memory limit",


### PR DESCRIPTION
Allow users to set CPU and memory requests/limits via `reana.yaml`. If not specified, default values configured by cluster admins will be applied.

Closes reanahub/reana#883