### PR TITLE
fix(snakemake): update Snakemake to 9.1.0 and snakemake-storage-plug…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,10 +40,10 @@ extras_require = {
     "snakemake": [
         "snakemake==7.32.4 ; python_version<'3.11'",
         "pulp>=2.7.0,<2.8.0 ; python_version<'3.11'",
-        "snakemake==8.27.1 ; python_version>='3.11'",
+        "snakemake==9.1.0 ; python_version>='3.11'",
     ],
     "snakemake-xrootd": [
-        "snakemake-storage-plugin-xrootd==0.1.4 ; python_version>='3.11'",
+        "snakemake-storage-plugin-xrootd==0.4.1 ; python_version>='3.11'",
     ],
 }
 


### PR DESCRIPTION
## Summary

This PR updates the Snakemake and snakemake-storage-plugin-xrootd dependencies in `reana-commons` to resolve installation issues caused by the unmaintained `datrie` library on modern Linux systems (GCC >=14).  
Closes [#494](https://github.com/reanahub/reana-commons/issues/494).

---

## Problem

- Installing `reana-client` or any component depending on `reana-commons[snakemake]` fails on modern Linux distributions due to compilation errors in the `datrie` dependency.
- `datrie` is unmaintained ([pytries/datrie#101](https://github.com/pytries/datrie/issues/101)), and although a fix exists ([pytries/datrie#99](https://github.com/pytries/datrie/pull/99)), it has not been merged.
- Snakemake removed the `datrie` dependency in [snakemake/snakemake#3176](https://github.com/snakemake/snakemake/pull/3176), available since [v8.29.1](https://github.com/snakemake/snakemake/releases/tag/v8.29.1).

---

## Solution

- Update Snakemake to `9.1.0` (used in snakemake-storage-plugin-xrootd) for Python >=3.11 to remove the `datrie` dependency.
- Update `snakemake-storage-plugin-xrootd` to `0.4.1` for compatibility with Snakemake 9.1.0.
- No other functional changes.

---

## Testing

- All `reana-commons` tests pass locally:  

```
186 passed, 4 xfailed (xfailed tests are expected and match current CI results and with original upstream)
```

- Installed this branch in `reana-client` and ran all tests:

```
168 passed, 1 xfailed, 2917 warnings (results are consistent with the original upstream)
```

- Ran the `roofit` example from reanahub: finished successfully.
- Ran reanahub Snakemake example of reana-demo-root6-roofit: finished successfully.

---

## References

- [pytries/datrie#101](https://github.com/pytries/datrie/issues/101)
- [pytries/datrie#99](https://github.com/pytries/datrie/pull/99)
- [snakemake/snakemake#3176](https://github.com/snakemake/snakemake/pull/3176)
- [snakemake/snakemake#3105](https://github.com/snakemake/snakemake/issues/3105)
- [snakemake/snakemake#2970](https://github.com/snakemake/snakemake/issues/2970)
- [snakemake v8.29.1 release notes](https://github.com/snakemake/snakemake/releases/tag/v8.29.1)

---

## Impact

This PR fix the installation of any component depending on `reana-commons[snakemake]` on modern Linux distributions and affects reproducibility and maintainability for new users and contributors.

This will fix the reana-client installing error

Let me know if I'm wrong, clarify any detail or if more tests are needed.

---

Closes #494