### PR TITLE
feat(openapi): add JWT-based Authorization header across `reana-server` API spec

### DIFF
--- a/reana_commons/openapi_specifications/reana_server.json
+++ b/reana_commons/openapi_specifications/reana_server.json
@@ -2,7 +2,7 @@
   "info": {
     "description": "Submit workflows to be run on REANA Cloud",
     "title": "REANA Server",
-    "version": "0.95.0a2"
+    "version": "0.95.0a3"
   },
   "paths": {
     "/account/settings/linkedaccounts/": {},
@@ -16,6 +16,13 @@
             "description": "API access_token of user.",
             "in": "query",
             "name": "access_token",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "The JWT of user.",
+            "in": "header",
+            "name": "Authorization",
             "required": false,
             "type": "string"
           }
@@ -149,6 +156,13 @@
             "description": "The API access_token of the current user.",
             "in": "query",
             "name": "access_token",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "The JWT of the current user.",
+            "in": "header",
+            "name": "Authorization",
             "required": false,
             "type": "string"
           },
@@ -409,7 +423,14 @@
             "description": "The API access_token of workflow owner.",
             "in": "query",
             "name": "access_token",
-            "required": true,
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "The JWT of the workflow owner.",
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
             "type": "string"
           }
         ],
@@ -1043,6 +1064,13 @@
             "name": "access_token",
             "required": false,
             "type": "string"
+          },
+          {
+            "description": "The JWT of secrets owner.",
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "type": "string"
           }
         ],
         "produces": [
@@ -1128,6 +1156,13 @@
             "description": "API key of the admin.",
             "in": "query",
             "name": "access_token",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "The JWT of the admin.",
+            "in": "header",
+            "name": "Authorization",
             "required": false,
             "type": "string"
           },
@@ -1227,6 +1262,13 @@
             "description": "Secrets owner access token.",
             "in": "query",
             "name": "access_token",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "The JWT of secrets owner.",
+            "in": "header",
+            "name": "Authorization",
             "required": false,
             "type": "string"
           },
@@ -1508,6 +1550,13 @@
             "name": "access_token",
             "required": false,
             "type": "string"
+          },
+          {
+            "description": "The JWT of the current user.",
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "type": "string"
           }
         ],
         "produces": [
@@ -1602,6 +1651,13 @@
             "description": "API access_token of user.",
             "in": "query",
             "name": "access_token",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "The JWT of the current user.",
+            "in": "header",
+            "name": "Authorization",
             "required": false,
             "type": "string"
           }
@@ -1701,6 +1757,13 @@
             "name": "access_token",
             "required": false,
             "type": "string"
+          },
+          {
+            "description": "The JWT of current user.",
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "type": "string"
           }
         ],
         "produces": [
@@ -1796,6 +1859,13 @@
             "description": "The API access_token of workflow owner.",
             "in": "query",
             "name": "access_token",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "The JWT of the workflow owner.",
+            "in": "header",
+            "name": "Authorization",
             "required": false,
             "type": "string"
           },
@@ -2195,6 +2265,13 @@
             "name": "access_token",
             "required": false,
             "type": "string"
+          },
+          {
+            "description": "The JWT of the workflow owner.",
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "type": "string"
           }
         ],
         "produces": [
@@ -2329,6 +2406,13 @@
             "description": "The API access_token of workflow owner.",
             "in": "query",
             "name": "access_token",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "The JWT of the workflow owner.",
+            "in": "header",
+            "name": "Authorization",
             "required": false,
             "type": "string"
           }
@@ -2486,6 +2570,13 @@
             "name": "access_token",
             "required": false,
             "type": "string"
+          },
+          {
+            "description": "The JWT of the workflow owner.",
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "type": "string"
           }
         ],
         "produces": [
@@ -2605,6 +2696,13 @@
             "name": "access_token",
             "required": false,
             "type": "string"
+          },
+          {
+            "description": "The JWT of the workflow owner.",
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "type": "string"
           }
         ],
         "produces": [
@@ -2704,6 +2802,13 @@
             "description": "The API access_token of workflow owner.",
             "in": "query",
             "name": "access_token",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "The JWT of the workflow owner.",
+            "in": "header",
+            "name": "Authorization",
             "required": false,
             "type": "string"
           },
@@ -2878,6 +2983,13 @@
             "type": "string"
           },
           {
+            "description": "The JWT of the workflow owner.",
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "type": "string"
+          },
+          {
             "description": "Required. Analysis UUID or name.",
             "in": "path",
             "name": "workflow_id_or_name",
@@ -3040,6 +3152,13 @@
             "type": "string"
           },
           {
+            "description": "The JWT of the workflow owner.",
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "type": "string"
+          },
+          {
             "description": "Type of interactive session to use.",
             "in": "path",
             "name": "interactive_session_type",
@@ -3168,6 +3287,13 @@
             "name": "access_token",
             "required": false,
             "type": "string"
+          },
+          {
+            "description": "The JWT of the workflow owner.",
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "type": "string"
           }
         ],
         "produces": [
@@ -3285,6 +3411,13 @@
             "description": "The API access_token of workflow owner.",
             "in": "query",
             "name": "access_token",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "The JWT of the workflow owner.",
+            "in": "header",
+            "name": "Authorization",
             "required": false,
             "type": "string"
           },
@@ -3415,6 +3548,13 @@
             "description": "The API access_token of workflow owner.",
             "in": "query",
             "name": "access_token",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "The JWT of the workflow owner.",
+            "in": "header",
+            "name": "Authorization",
             "required": false,
             "type": "string"
           },
@@ -3560,6 +3700,13 @@
             "description": "The API access_token of workflow owner.",
             "in": "query",
             "name": "access_token",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "The JWT of the workflow owner.",
+            "in": "header",
+            "name": "Authorization",
             "required": false,
             "type": "string"
           },
@@ -3733,6 +3880,13 @@
             "type": "string"
           },
           {
+            "description": "The JWT of the workflow owner.",
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "type": "string"
+          },
+          {
             "description": "Required. Workflow UUID or name.",
             "in": "path",
             "name": "workflow_id_or_name",
@@ -3862,6 +4016,13 @@
             "description": "API access_token of workflow owner.",
             "in": "query",
             "name": "access_token",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "The JWT of the workflow owner.",
+            "in": "header",
+            "name": "Authorization",
             "required": false,
             "type": "string"
           },
@@ -4072,6 +4233,13 @@
             "type": "string"
           },
           {
+            "description": "The JWT of the workflow owner.",
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "type": "string"
+          },
+          {
             "description": "Optional. Additional input parameters and operational options.",
             "in": "body",
             "name": "parameters",
@@ -4251,6 +4419,13 @@
             "description": "The API access_token of workflow owner.",
             "in": "query",
             "name": "access_token",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "The JWT of the workflow owner.",
+            "in": "header",
+            "name": "Authorization",
             "required": false,
             "type": "string"
           }
@@ -4498,6 +4673,13 @@
             "type": "string"
           },
           {
+            "description": "The JWT of the workflow owner.",
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "type": "string"
+          },
+          {
             "description": "Optional. Additional parameters to customise the workflow status change.",
             "in": "body",
             "name": "parameters",
@@ -4678,6 +4860,13 @@
             "type": "string"
           },
           {
+            "description": "The JWT of the workflow owner.",
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "type": "string"
+          },
+          {
             "description": "Required. Workflow UUID or name.",
             "in": "path",
             "name": "workflow_id_or_name",
@@ -4820,6 +5009,13 @@
             "description": "The API access_token of workflow owner.",
             "in": "query",
             "name": "access_token",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "The JWT of the workflow owner.",
+            "in": "header",
+            "name": "Authorization",
             "required": false,
             "type": "string"
           },
@@ -4997,6 +5193,13 @@
             "type": "string"
           },
           {
+            "description": "The JWT of the workflow owner.",
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "type": "string"
+          },
+          {
             "description": "Optional flag to return a previewable response of the file (corresponding mime-type).",
             "in": "query",
             "name": "preview",
@@ -5112,6 +5315,13 @@
             "name": "access_token",
             "required": false,
             "type": "string"
+          },
+          {
+            "description": "The JWT of the workflow owner.",
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "type": "string"
           }
         ],
         "produces": [
@@ -5223,6 +5433,13 @@
             "name": "access_token",
             "required": false,
             "type": "string"
+          },
+          {
+            "description": "The JWT of the workflow owner.",
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "type": "string"
           }
         ],
         "produces": [
@@ -5311,6 +5528,13 @@
             "description": "API access_token of user.",
             "in": "query",
             "name": "access_token",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "The JWT of the current user.",
+            "in": "header",
+            "name": "Authorization",
             "required": false,
             "type": "string"
           }


### PR DESCRIPTION
This pull request updates the OpenAPI specifications of the REANA Server to support JWT-based authorization. The primary change is the introduction of a new `Authorization` header parameter across multiple endpoints to enable JWT authentication. The placement and optionality of this header follow the existing conventions used for the `access_token` parameter to ensure consistency across the authorization setup.

More information on our efforts and progress can be found in [this issue](https://github.com/reanahub/reana-server/issues/743) 