### PR TITLE
refactor(config): replace deprecated pkg_resources

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ install_requires = [
     "checksumdir>=1.1.4,<1.2",
     "click>=7.0",
     "fs>=2.0",
+    "importlib_resources>=5.0; python_version<'3.9'",
     "jsonschema[format]>=3.0.1",
     "kombu>=4.6",
     "mock>=3.0,<4",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,12 +10,13 @@
 
 import os
 import shutil
+import sys
 import time
 from hashlib import md5
 
-import pkg_resources
 import pytest
 from pytest_reana.fixtures import sample_workflow_workspace
+
 
 from reana_commons.utils import (
     calculate_file_access_time,
@@ -70,9 +71,14 @@ def test_calculate_hash_of_dir(sample_workflow_workspace):  # noqa: F811
     non_existing_dir_hash = calculate_hash_of_dir("a/b/c")
     assert non_existing_dir_hash == -1
 
-    test_workspace_path = pkg_resources.resource_filename(
-        "pytest_reana", "test_workspace"
-    )
+    # Get the path to the test workspace by finding the pytest_reana package location
+    import pytest_reana
+    import pathlib
+
+    # Get the package path and construct test_workspace path
+    package_path = pathlib.Path(pytest_reana.__file__).parent
+    test_workspace_path = package_path / "test_workspace"
+
     sample_workflow_workspace_path = next(sample_workflow_workspace("sample"))
     shutil.rmtree(sample_workflow_workspace_path)
     shutil.copytree(test_workspace_path, sample_workflow_workspace_path)


### PR DESCRIPTION
Replace `pkg_resources`` with the modern `importlib.resources` API to resolve deprecation warnings. Uses `importlib.resources`` for Python 3.9+ and the `importlib_resources` backport for Python 3.8 compatibility.

Closes #502