### PR TITLE
build(python): pin google-auth for Python 3.8 compatibility

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (C) 2018, 2019, 2020, 2021, 2022, 2023, 2024 CERN.
+Copyright (C) 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026 CERN.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/reana_commons/version.py
+++ b/reana_commons/version.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025 CERN.
+# Copyright (C) 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.95.0a11"
+__version__ = "0.95.0a12"

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025 CERN.
+# Copyright (C) 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -29,6 +29,7 @@ extras_require = {
     ],
     "kubernetes": [
         "kubernetes>=22.0.0,<23.0.0",
+        "google-auth<2.46.0; python_version<'3.9'",
     ],
     "yadage": [
         "adage~=0.11.0",


### PR DESCRIPTION
The google-auth 2.46.0 added type annotations using `Sequence[str]` without `from __future__ import annotations`, which causes `TypeError: 'ABCMeta' object is not subscriptable` on Python 3.8. This commit pins the google-auth package for Python 3.8 only in order to fix this problem, whilst Python 3.9+ can use any compatible version.