### PR TITLE
fix(openapi): add gitlab_host schema definition

### DIFF
--- a/reana_commons/gherkin_parser/functions.py
+++ b/reana_commons/gherkin_parser/functions.py
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2024 CERN.
+# Copyright (C) 2024, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -466,9 +466,7 @@ def file_content_contain(workflow, filename, content, data_fetcher):
     filename = _strip_quotes(filename)
     if not filename.startswith("/"):
         filename = f"/{filename}"  # Add leading slash if needed
-    (file_content, file_name, is_archive) = data_fetcher.download_file(
-        workflow, filename
-    )
+    file_content, file_name, is_archive = data_fetcher.download_file(workflow, filename)
     if is_archive:
         raise StepSkipped("This test is not supported for archive files.")
     assert content in file_content.decode(
@@ -500,9 +498,7 @@ def file_checksum(workflow, algorithm, filename, checksum, data_fetcher):
         raise Exception(
             f"The specified checksum algorithm is not supported! Supported algorithms: {supported_algorithms}"
         )
-    (file_content, file_name, is_archive) = data_fetcher.download_file(
-        workflow, filename
-    )
+    file_content, file_name, is_archive = data_fetcher.download_file(workflow, filename)
     # Checksum the file content
     if algorithm.lower() == "adler32":
         h = zlib.adler32(file_content)

--- a/reana_commons/k8s/kerberos.py
+++ b/reana_commons/k8s/kerberos.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2022, 2024 CERN.
+# Copyright (C) 2022, 2024, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -24,7 +24,6 @@ from reana_commons.config import (
 )
 from reana_commons.errors import REANASecretDoesNotExist
 from reana_commons.k8s.secrets import UserSecrets
-
 
 KerberosConfig = namedtuple(
     "KerberosConfig",

--- a/reana_commons/k8s/secrets.py
+++ b/reana_commons/k8s/secrets.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2019, 2020, 2021 CERN.
+# Copyright (C) 2019, 2020, 2021, 2022, 2024, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """REANA Kubernetes secrets."""
+
 import base64
 import binascii
 import json

--- a/reana_commons/openapi_specifications/reana_job_controller.json
+++ b/reana_commons/openapi_specifications/reana_job_controller.json
@@ -140,7 +140,7 @@
   "info": {
     "description": "REANA Job Controller API",
     "title": "reana-job-controller",
-    "version": "0.9.4"
+    "version": "0.95.0a3"
   },
   "paths": {
     "/apispec": {},

--- a/reana_commons/openapi_specifications/reana_server.json
+++ b/reana_commons/openapi_specifications/reana_server.json
@@ -2,7 +2,7 @@
   "info": {
     "description": "Submit workflows to be run on REANA Cloud",
     "title": "REANA Server",
-    "version": "0.95.0a3"
+    "version": "0.95.0a4"
   },
   "paths": {
     "/account/settings/linkedaccounts/": {},
@@ -768,6 +768,17 @@
                   "type": "object"
                 },
                 "default_workspace": {
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "gitlab_host": {
                   "properties": {
                     "title": {
                       "type": "string"

--- a/reana_commons/openapi_specifications/reana_workflow_controller.json
+++ b/reana_commons/openapi_specifications/reana_workflow_controller.json
@@ -2,7 +2,7 @@
   "info": {
     "description": "Submit and manage workflows",
     "title": "REANA Workflow Controller",
-    "version": "0.95.0a1"
+    "version": "0.95.0a5"
   },
   "paths": {
     "/api/workflows": {

--- a/reana_commons/utils.py
+++ b/reana_commons/utils.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2018, 2019, 2020, 2021, 2022, 2023 CERN.
+# Copyright (C) 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 """REANA-Commons utils."""
-
 
 import datetime
 import json

--- a/reana_commons/validation/parameters.py
+++ b/reana_commons/validation/parameters.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2021, 2022 CERN.
+# Copyright (C) 2021, 2022, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """REANA-Commons parameters validation."""
-
 
 import os
 import re

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2022 CERN.
+# Copyright (C) 2022, 2023, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """REANA-Commons validation testing."""
+
 import operator
 
 import pytest

--- a/tests/test_volumes.py
+++ b/tests/test_volumes.py
@@ -1,9 +1,10 @@
 # This file is part of REANA.
-# Copyright (C) 2023 CERN.
+# Copyright (C) 2023, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 """REANA-Commons volume utilities testing."""
+
 from reana_commons.k8s.volumes import get_k8s_cvmfs_volumes
 
 


### PR DESCRIPTION
Sync with reana-server fix that adds missing schema for gitlab_host in the info endpoint OpenAPI specification. Complements d7c27ac.

Also updates version numbers of the OpenAPI specifications of the reana-job-controller component and the reana-workflow-controller component for consistency with their latest versions.