### PR TITLE
build(python): pin setuptools below 81

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,5 +4,6 @@
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
+setuptools<81
 -e .[docs]
 -e .[kubernetes]

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ extras_require = {
     ],
     "yadage": [
         "adage~=0.11.0",
+        "setuptools<81",  # pkg_resources needed by yadage-schemas
         "yadage~=0.20.1",
         "yadage-schemas~=0.10.6",
         "jsonschema<4.10.0",  # see https://github.com/yadage/yadage-schemas/issues/38

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2022, 2023, 2024, 2025 CERN.
+# Copyright (C) 2022, 2023, 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -18,6 +18,7 @@ envlist =
 deps =
     pytest
     pytest-cov
+    setuptools<81
 commands =
     pytest {posargs}
 extras =


### PR DESCRIPTION
Pin setuptools<81 in the yadage extras. This is needed because yadage-schemas uses the pkg_resources module that was removed in setuptools 81.0.0.