### PR TITLE
build(python): upgrade to Snakemake 9.16.3 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          pip install -e .[all]
+          pip install -e .[docs,kubernetes]
 
       - name: Run Sphinx documentation with doctests
         run: ./run-tests.sh --check-sphinx
@@ -162,7 +162,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           pip install twine wheel
-          pip install -e .[all]
+          pip install -e .[cwl,docs,kubernetes,snakemake,tests,yadage]
 
       - name: Run pytest
         run: ./run-tests.sh --check-pytest

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -5,6 +5,7 @@ The list of contributors in alphabetical order:
 - [Adelina Lintuluoto](https://orcid.org/0000-0002-0726-1452)
 - [Agisilaos Kounelis](https://orcid.org/0000-0001-9312-3189)
 - [Alastair Lyall](https://orcid.org/0009-0000-4955-8935)
+- [Alejandro Gomez Espinosa](https://orcid.org/0000-0002-9443-7769)
 - [Alp Tuna](https://orcid.org/0009-0001-1915-3993)
 - [Audrius Mecionis](https://orcid.org/0000-0002-3759-1663)
 - [Bruno Rosendo](https://orcid.org/0000-0002-0923-3148)

--- a/reana_commons/version.py
+++ b/reana_commons/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.95.0a12"
+__version__ = "0.95.0a13"

--- a/setup.py
+++ b/setup.py
@@ -25,10 +25,10 @@ extras_require = {
         "sphinx-rtd-theme>=0.1.9",
     ],
     "tests": [
-        "pytest-reana>=0.95.0a5,<0.96.0",
+        "pytest-reana>=0.95.0a7,<0.96.0",
     ],
     "kubernetes": [
-        "kubernetes>=22.0.0,<23.0.0",
+        "kubernetes>=22.0.0,<27.0.0",  # upper pin due to oauthlib 3.x incompatibility with reana-server invenio packages
         "google-auth<2.46.0; python_version<'3.9'",
     ],
     "yadage": [
@@ -42,10 +42,13 @@ extras_require = {
     "snakemake": [
         "snakemake==7.32.4 ; python_version<'3.11'",
         "pulp>=2.7.0,<2.8.0 ; python_version<'3.11'",
-        "snakemake==8.27.1 ; python_version>='3.11'",
+        "snakemake==9.16.3 ; python_version>='3.11'",
+    ],
+    "snakemake-kubernetes": [
+        "snakemake-executor-plugin-kubernetes>=0.1.5 ; python_version>='3.11'",
     ],
     "snakemake-xrootd": [
-        "snakemake-storage-plugin-xrootd==0.1.4 ; python_version>='3.11'",
+        "snakemake-storage-plugin-xrootd==1.0.0 ; python_version>='3.11'",
     ],
 }
 

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,11 @@ deps =
 commands =
     pytest {posargs}
 extras =
-    all
+    cwl
+    docs
+    kubernetes
+    snakemake
+    tests
+    yadage
 package =
     editable


### PR DESCRIPTION
This PR updates the Snakemake dependency to v9.16.3 for Python 3.11+ environments.
 
**Changes**:

* Updated `snakemake` pin to `9.16.3`.
* Added `snakemake-executor-plugin-kubernetes` (required since Snakemake v8+ extracted executors to plugins).

**Verification**:

* Verified locally by building `reana-workflow-engine-snakemake` with this branch and running the `root6-roofit` demo successfully.