### PR TITLE
ci(run-tests): refactor run-tests.sh and add linter checks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace=true
+
+[*.{css,html,js,json,scss,yaml,yml}]
+indent_size = 2
+
+[*.{py,sh}]
+indent_size = 4
+
+[*.go]
+indent_style = tab

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,24 @@ jobs:
           sudo apt-get install shellcheck
           ./run-tests.sh --lint-shellcheck
 
+  lint-yamllint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Lint YAML files
+        run: |
+          pip install yamllint
+          ./run-tests.sh --lint-yamllint
+
   python-tests:
     runs-on: ubuntu-24.04
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,112 +4,11 @@
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-name: CI
+name: ci
 
 on: [push, pull_request]
 
 jobs:
-  lint-commitlint:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-
-      - name: Install commitlint
-        run: |
-          npm install conventional-changelog-conventionalcommits
-          npm install commitlint@latest
-
-      - name: Check commit message compliance of the recently pushed commit
-        if: github.event_name == 'push'
-        run: |
-          ./run-tests.sh --check-commitlint HEAD~1 HEAD
-
-      - name: Check commit message compliance of the pull request
-        if: github.event_name == 'pull_request'
-        run: |
-          ./run-tests.sh --check-commitlint ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.number }}
-
-  lint-shellcheck:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Runs shell script static analysis
-        run: |
-          sudo apt-get install shellcheck
-          ./run-tests.sh --check-shellcheck
-
-  lint-black:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Check Python code formatting
-        run: |
-          pip install black
-          ./run-tests.sh --check-black
-
-  lint-flake8:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Check compliance with pep8, pyflakes and circular complexity
-        run: |
-          pip install flake8
-          ./run-tests.sh --check-flake8
-
-  lint-pydocstyle:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Check compliance with Python docstring conventions
-        run: |
-          pip install pydocstyle
-          ./run-tests.sh --check-pydocstyle
-
-  lint-check-manifest:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Check Python manifest completeness
-        run: |
-          pip install check-manifest
-          ./run-tests.sh --check-manifest
-
   docs-sphinx:
     runs-on: ubuntu-24.04
     steps:
@@ -137,7 +36,108 @@ jobs:
           pip install -e .[docs,kubernetes]
 
       - name: Run Sphinx documentation with doctests
-        run: ./run-tests.sh --check-sphinx
+        run: ./run-tests.sh --docs-sphinx
+
+  format-black:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Check Python code formatting
+        run: |
+          pip install black
+          ./run-tests.sh --format-black
+
+  lint-commitlint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Install commitlint
+        run: |
+          npm install conventional-changelog-conventionalcommits
+          npm install commitlint@latest
+
+      - name: Check commit message compliance of the recently pushed commit
+        if: github.event_name == 'push'
+        run: |
+          ./run-tests.sh --lint-commitlint HEAD~1 HEAD
+
+      - name: Check commit message compliance of the pull request
+        if: github.event_name == 'pull_request'
+        run: |
+          ./run-tests.sh --lint-commitlint ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.number }}
+
+  lint-flake8:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Check compliance with pep8, pyflakes and circular complexity
+        run: |
+          pip install flake8
+          ./run-tests.sh --lint-flake8
+
+  lint-manifest:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Check Python manifest completeness
+        run: |
+          pip install check-manifest
+          ./run-tests.sh --lint-manifest
+
+  lint-pydocstyle:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Check compliance with Python docstring conventions
+        run: |
+          pip install pydocstyle
+          ./run-tests.sh --lint-pydocstyle
+
+  lint-shellcheck:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Runs shell script static analysis
+        run: |
+          sudo apt-get install shellcheck
+          ./run-tests.sh --lint-shellcheck
 
   python-tests:
     runs-on: ubuntu-24.04
@@ -165,7 +165,7 @@ jobs:
           pip install -e .[cwl,docs,kubernetes,snakemake,tests,yadage]
 
       - name: Run pytest
-        run: ./run-tests.sh --check-pytest
+        run: ./run-tests.sh --python-tests
 
       - name: Codecov Coverage
         if: matrix.python-version == '3.12'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,20 @@ jobs:
         run: |
           ./run-tests.sh --lint-commitlint ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.number }}
 
+  lint-jsonlint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Lint JSON files
+        run: |
+          npm install jsonlint --global
+          ./run-tests.sh --lint-jsonlint
+
   lint-flake8:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,20 @@ jobs:
           pip install black
           ./run-tests.sh --format-black
 
+  format-prettier:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Check Prettier code formatting
+        run: |
+          npm install prettier --global
+          ./run-tests.sh --format-prettier
+
   format-shfmt:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,17 @@ jobs:
           pip install black
           ./run-tests.sh --format-black
 
+  format-shfmt:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check shell script code formatting
+        run: |
+          sudo apt-get install shfmt
+          ./run-tests.sh --format-shfmt
+
   lint-commitlint:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,20 @@ jobs:
           pip install flake8
           ./run-tests.sh --lint-flake8
 
+  lint-markdownlint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Lint Markdown files
+        run: |
+          npm install markdownlint-cli2 --global
+          ./run-tests.sh --lint-markdownlint
+
   lint-manifest:
     runs-on: ubuntu-24.04
     steps:

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,2 @@
+# Allow prompt dollar sign in console examples without showing output
+MD014: false

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+.pytest_cache
+CHANGELOG.md

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,2 @@
+printWidth: 80
+proseWrap: always

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -5,9 +5,13 @@
     ".": {
       "changelog-sections": [
         { "type": "build", "section": "Build", "hidden": false },
-        { "type": "feat", "section": "Features", "hidden": false  },
+        { "type": "feat", "section": "Features", "hidden": false },
         { "type": "fix", "section": "Bug fixes", "hidden": false },
-        { "type": "perf", "section": "Performance improvements", "hidden": false },
+        {
+          "type": "perf",
+          "section": "Performance improvements",
+          "hidden": false
+        },
         { "type": "refactor", "section": "Code refactoring", "hidden": false },
         { "type": "style", "section": "Code style", "hidden": false },
         { "type": "test", "section": "Test suite", "hidden": false },

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,8 @@
+extends: default
+
+rules:
+  comments:
+    min-spaces-from-content: 1
+  document-start: disable
+  line-length: disable
+  truthy: disable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
+<!-- markdownlint-disable MD013 -->
+<!-- markdownlint-disable MD024 -->
+
 # Changelog
 
 ## [0.9.11](https://github.com/reanahub/reana-commons/compare/0.9.10...0.9.11) (2025-04-07)
-
 
 ### Bug fixes
 
@@ -9,28 +11,23 @@
 
 ## [0.9.10](https://github.com/reanahub/reana-commons/compare/0.9.9...0.9.10) (2025-04-04)
 
-
 ### Features
 
 * **openapi:** add K8s resource requests and limits in reana.yaml ([#486](https://github.com/reanahub/reana-commons/issues/486)) ([53457cb](https://github.com/reanahub/reana-commons/commit/53457cbc6a431561d299554842e2ad4affade13d))
 
 ## [0.9.9](https://github.com/reanahub/reana-commons/compare/0.9.8...0.9.9) (2024-11-28)
 
-
 ### Build
 
 * **python:** add support for Python 3.13 ([#480](https://github.com/reanahub/reana-commons/issues/480)) ([5de7605](https://github.com/reanahub/reana-commons/commit/5de760512a3aa86282a9dc31ac031773ddf49ef6))
-
 
 ### Features
 
 * **schema:** allow Compute4PUNCH backend options ([#445](https://github.com/reanahub/reana-commons/issues/445)) ([0570f4a](https://github.com/reanahub/reana-commons/commit/0570f4ade9135a2d340009d2091c97dfc81a2e60))
 
-
 ### Bug fixes
 
 * **config:** remove hard-coded component host name domain ([#458](https://github.com/reanahub/reana-commons/issues/458)) ([f2faeaa](https://github.com/reanahub/reana-commons/commit/f2faeaa76f42c4484db70766fc1d7a3a122ee38f)), closes [#457](https://github.com/reanahub/reana-commons/issues/457)
-
 
 ### Continuous integration
 
@@ -38,13 +35,11 @@
 
 ## [0.9.8](https://github.com/reanahub/reana-commons/compare/0.9.7...0.9.8) (2024-03-01)
 
-
 ### Build
 
 * **python:** change extra names to comply with PEP 685 ([#446](https://github.com/reanahub/reana-commons/issues/446)) ([9dad6da](https://github.com/reanahub/reana-commons/commit/9dad6da7b80bc07423d45dab7b6799911740a082))
 * **python:** require smart-open&lt;7 for Python 3.6 ([#446](https://github.com/reanahub/reana-commons/issues/446)) ([17fd581](https://github.com/reanahub/reana-commons/commit/17fd581d4928d5c377f67bcb77c4f245e661c395))
 * **python:** restore snakemake `reports` extra ([#446](https://github.com/reanahub/reana-commons/issues/446)) ([904178f](https://github.com/reanahub/reana-commons/commit/904178fe454b9af39164a0c327f1ecd1663132af))
-
 
 ### Continuous integration
 
@@ -52,11 +47,9 @@
 
 ## [0.9.7](https://github.com/reanahub/reana-commons/compare/0.9.6...0.9.7) (2024-02-20)
 
-
 ### Build
 
 * **snakemake:** require pulp&lt;2.8.0 ([#444](https://github.com/reanahub/reana-commons/issues/444)) ([5daa109](https://github.com/reanahub/reana-commons/commit/5daa109a58066126c2d8a35e7cd7da70d4137f62))
-
 
 ### Documentation
 
@@ -64,22 +57,18 @@
 
 ## [0.9.6](https://github.com/reanahub/reana-commons/compare/0.9.5...0.9.6) (2024-02-13)
 
-
 ### Features
 
 * **config:** allow customisation of runtime group name ([#440](https://github.com/reanahub/reana-commons/issues/440)) ([5cec305](https://github.com/reanahub/reana-commons/commit/5cec30561ba21e2ea695e20eaea8171226f06e52))
 * **snakemake:** upgrade to Snakemake 7.32.4 ([#435](https://github.com/reanahub/reana-commons/issues/435)) ([20ae9ce](https://github.com/reanahub/reana-commons/commit/20ae9cebf19a1fdb77ad08956db04ef026521b5d))
 
-
 ### Bug fixes
 
 * **cache:** handle deleted files when calculating access times ([#437](https://github.com/reanahub/reana-commons/issues/437)) ([698900f](https://github.com/reanahub/reana-commons/commit/698900fc63e20bd54dcc4a5faa6cac0be5d0d8de))
 
-
 ### Code refactoring
 
 * **docs:** move from reST to Markdown ([#441](https://github.com/reanahub/reana-commons/issues/441)) ([36ce4e0](https://github.com/reanahub/reana-commons/commit/36ce4e0a86484e3a7006e20545a892424ce0f3a2))
-
 
 ### Continuous integration
 
@@ -91,214 +80,214 @@
 
 ## 0.9.5 (2023-12-15)
 
-- Fixes installation by pinning `bravado-core` to versions lower than 6.1.1.
+* Fixes installation by pinning `bravado-core` to versions lower than 6.1.1.
 
 ## 0.9.4 (2023-11-30)
 
-- Changes the REANA specification schema to use the `draft-07` version of the JSON Schema specification.
-- Changes validation of REANA specification to expose functions for loading workflow input parameters and workflow specifications.
-- Changes validation of REANA specification to make the `environment` property mandatory for the steps of serial workflows.
-- Changes validation of REANA specification to raise a warning for unexpected properties for the steps of serial workflows.
-- Changes CVMFS support to allow users to automatically mount any available repository.
-- Fixes the mounting of CVMFS volumes for the REANA deployments that use non-default Kubernetes namespace.
+* Changes the REANA specification schema to use the `draft-07` version of the JSON Schema specification.
+* Changes validation of REANA specification to expose functions for loading workflow input parameters and workflow specifications.
+* Changes validation of REANA specification to make the `environment` property mandatory for the steps of serial workflows.
+* Changes validation of REANA specification to raise a warning for unexpected properties for the steps of serial workflows.
+* Changes CVMFS support to allow users to automatically mount any available repository.
+* Fixes the mounting of CVMFS volumes for the REANA deployments that use non-default Kubernetes namespace.
 
 ## 0.9.3 (2023-09-26)
 
-- Adds support for Python 3.12.
-- Adds the OpenAPI specification support for `prune_workspace` endpoint that allows to delete files that are neither inputs nor outputs from the workspace.
-- Adds support for `tests.files` in `reana.yaml` allowing to specify Gherkin feature files for testing runnable examples.
-- Changes the OpenAPI specification to include the `run_stopped_at` property in the workflow progress information returned by the workflow list and workflow status endpoints.
-- Changes the OpenAPI specification to include the `maximum_interactive_session_inactivity_period` value to the `info` endpoint.
-- Changes the email sending utility to allow configuring authentication and encryption options.
-- Changes validation of REANA specification to emit warnings about unknown properties.
-- Fixes the verbs used to describe changes to the status of a workflow in order to avoid incorrect grammatical phrases such as `workflow has been failed`.
-- Fixes the loading of Snakemake and CWL workflow specifications when no parameters are specified.
-- Fixes the OpenAPI specification of GitLab OAuth endpoint return statuses.
-- Fixes container image names to be Podman-compatible.
-- Fixes the email sending utility to not send emails when notifications are disabled globally.
+* Adds support for Python 3.12.
+* Adds the OpenAPI specification support for `prune_workspace` endpoint that allows to delete files that are neither inputs nor outputs from the workspace.
+* Adds support for `tests.files` in `reana.yaml` allowing to specify Gherkin feature files for testing runnable examples.
+* Changes the OpenAPI specification to include the `run_stopped_at` property in the workflow progress information returned by the workflow list and workflow status endpoints.
+* Changes the OpenAPI specification to include the `maximum_interactive_session_inactivity_period` value to the `info` endpoint.
+* Changes the email sending utility to allow configuring authentication and encryption options.
+* Changes validation of REANA specification to emit warnings about unknown properties.
+* Fixes the verbs used to describe changes to the status of a workflow in order to avoid incorrect grammatical phrases such as `workflow has been failed`.
+* Fixes the loading of Snakemake and CWL workflow specifications when no parameters are specified.
+* Fixes the OpenAPI specification of GitLab OAuth endpoint return statuses.
+* Fixes container image names to be Podman-compatible.
+* Fixes the email sending utility to not send emails when notifications are disabled globally.
 
 ## 0.9.2.1 (2023-07-19)
 
-- Changes `PyYAML` dependency version bounds in order to fix installation on Python 3.10+.
+* Changes `PyYAML` dependency version bounds in order to fix installation on Python 3.10+.
 
 ## 0.9.2 (2023-02-10)
 
-- Fixes `wcmatch` dependency version specification.
+* Fixes `wcmatch` dependency version specification.
 
 ## 0.9.1 (2023-01-18)
 
-- Changes Kerberos renew container's configuration to log each ticket renewal.
+* Changes Kerberos renew container's configuration to log each ticket renewal.
 
 ## 0.9.0 (2022-12-13)
 
-- Adds support for Python 3.11.
-- Adds support for Rucio.
-- Adds REANA specification validation and loading logic from `reana-client`.
-- Adds common utility functions for managing workspace files.
-- Adds OpenAPI specification support for `launch` endpoint that allows running workflows from remote sources.
-- Adds OpenAPI specification support for `get_workflow_retention_rules` endpoint that allows to retrieve the workspace file retention rules of a workflow.
-- Adds generation of Kerberos init and renew container's configuration.
-- Adds support for Unicode characters inside email body.
-- Changes OpenAPI specification to include missing response schema elements and some other small enhancements.
-- Changes the Kubernetes Python client to use the `networking/v1` API.
-- Changes REANA specification loading functionality to allow specifying different working directories.
-- Changes REANA specification to allow enabling Kerberos for the whole workflow.
-- Changes REANA specification to allow specifying `retention_days` for the workflow.
-- Changes REANA specification to allow specifying `slurm_partition` and `slurm_time` for Slurm compute backend jobs.
-- Changes the loading of Snakemake specifications to preserve the current working directory.
-- Fixes the submission of jobs by stripping potential leading and trailing whitespaces in Docker image names.
+* Adds support for Python 3.11.
+* Adds support for Rucio.
+* Adds REANA specification validation and loading logic from `reana-client`.
+* Adds common utility functions for managing workspace files.
+* Adds OpenAPI specification support for `launch` endpoint that allows running workflows from remote sources.
+* Adds OpenAPI specification support for `get_workflow_retention_rules` endpoint that allows to retrieve the workspace file retention rules of a workflow.
+* Adds generation of Kerberos init and renew container's configuration.
+* Adds support for Unicode characters inside email body.
+* Changes OpenAPI specification to include missing response schema elements and some other small enhancements.
+* Changes the Kubernetes Python client to use the `networking/v1` API.
+* Changes REANA specification loading functionality to allow specifying different working directories.
+* Changes REANA specification to allow enabling Kerberos for the whole workflow.
+* Changes REANA specification to allow specifying `retention_days` for the workflow.
+* Changes REANA specification to allow specifying `slurm_partition` and `slurm_time` for Slurm compute backend jobs.
+* Changes the loading of Snakemake specifications to preserve the current working directory.
+* Fixes the submission of jobs by stripping potential leading and trailing whitespaces in Docker image names.
 
 ## 0.8.5 (2022-02-23)
 
-- Adds `retry_count` parameter to WorkflowSubmissionPublisher.
+* Adds `retry_count` parameter to WorkflowSubmissionPublisher.
 
 ## 0.8.4 (2022-02-08)
 
-- Adds new configuration variable to toggle Kubernetes security context. (`K8S_USE_SECURITY_CONTEXT`)
-- Changes installation to revert `Yadage` dependency versions.
+* Adds new configuration variable to toggle Kubernetes security context. (`K8S_USE_SECURITY_CONTEXT`)
+* Changes installation to revert `Yadage` dependency versions.
 
 ## 0.8.3 (2022-02-04)
 
-- Changes installation to remove upper version pin on `kombu`.
+* Changes installation to remove upper version pin on `kombu`.
 
 ## 0.8.2 (2022-02-01)
 
-- Adds support for Python 3.10.
-- Adds workflow name validation utility.
-- Changes `Snakemake` loaded specification to include compute backends.
-- Changes OpenAPI specification with respect to return supported compute backends in `info` endpoint.
-- Fixes file system usage calculation on CephFS shares in `get_disk_usage` utility function.
+* Adds support for Python 3.10.
+* Adds workflow name validation utility.
+* Changes `Snakemake` loaded specification to include compute backends.
+* Changes OpenAPI specification with respect to return supported compute backends in `info` endpoint.
+* Fixes file system usage calculation on CephFS shares in `get_disk_usage` utility function.
 
 ## 0.8.1 (2021-12-21)
 
-- Adds OpenAPI specification support for `kubernetes_job_timeout` handling.
-- Changes OpenAPI specification for cluster health status endpoint.
-- Changes Yadage dependencies to allow 0.21.x patchlevel-version updates.
-- Changes installation to require Python-3.6 or higher versions.
+* Adds OpenAPI specification support for `kubernetes_job_timeout` handling.
+* Changes OpenAPI specification for cluster health status endpoint.
+* Changes Yadage dependencies to allow 0.21.x patchlevel-version updates.
+* Changes installation to require Python-3.6 or higher versions.
 
 ## 0.8.0 (2021-11-22)
 
-- Adds `get_disk_usage` utility function to calculate disk usage for a directory.
-- Adds `Yadage` workflow specification loading utilities.
-- Adds workspace validation utilities.
-- Adds `Snakemake` workflow engine integration.
-- Adds custom objects API instance to k8s client.
-- Adds available worklow engines configuration.
-- Adds environment variable to define time between job controller connection checks.
-- Adds cluster health status endpoint.
-- Adds OpenAPI specifications with respect to user quotas.
-- Changes `workflow-submission` queue as a priority queue and allows to set the priority number on workflow submission.
-- Changes OpenAPI specifications with respect to turning `workspaces` endpoint into `info`.
-- Changes publisher logging level on error callback.
-- Removes support for Python 2.
+* Adds `get_disk_usage` utility function to calculate disk usage for a directory.
+* Adds `Yadage` workflow specification loading utilities.
+* Adds workspace validation utilities.
+* Adds `Snakemake` workflow engine integration.
+* Adds custom objects API instance to k8s client.
+* Adds available worklow engines configuration.
+* Adds environment variable to define time between job controller connection checks.
+* Adds cluster health status endpoint.
+* Adds OpenAPI specifications with respect to user quotas.
+* Changes `workflow-submission` queue as a priority queue and allows to set the priority number on workflow submission.
+* Changes OpenAPI specifications with respect to turning `workspaces` endpoint into `info`.
+* Changes publisher logging level on error callback.
+* Removes support for Python 2.
 
 ## 0.7.5 (2021-07-02)
 
-- Adds support for glob patterns when listing workflow files.
-- Adds support for specifying `kubernetes_memory_limit` for Kubernetes compute backend jobs.
+* Adds support for glob patterns when listing workflow files.
+* Adds support for specifying `kubernetes_memory_limit` for Kubernetes compute backend jobs.
 
 ## 0.7.4 (2021-03-17)
 
-- Adds new functions to serialise/deserialise job commands between REANA components.
-- Changes `reana_ready` function location to REANA-Server.
+* Adds new functions to serialise/deserialise job commands between REANA components.
+* Changes `reana_ready` function location to REANA-Server.
 
 ## 0.7.3 (2021-02-22)
 
-- Adds new configuration variable to toggle runtime user jobs clean up depending on their statuses. (`REANA_RUNTIME_KUBERNETES_KEEP_ALIVE_JOBS_WITH_STATUSES`)
-- Adds central class to instantiate workflow engines with more resilience. (`workflow_engine.create_workflow_engine_command`)
+* Adds new configuration variable to toggle runtime user jobs clean up depending on their statuses. (`REANA_RUNTIME_KUBERNETES_KEEP_ALIVE_JOBS_WITH_STATUSES`)
+* Adds central class to instantiate workflow engines with more resilience. (`workflow_engine.create_workflow_engine_command`)
 
 ## 0.7.2 (2021-02-02)
 
-- Adds support for Python 3.9.
-- Fixes minor code warnings.
-- Fixes a helper function that calculates directory hashes.
-- Changes OpenAPI specifications with respect to sign-up form.
-- Changes OpenAPI specifications with respect to email confirmation.
-- Changes CI system to include Python flake8 checker.
+* Adds support for Python 3.9.
+* Fixes minor code warnings.
+* Fixes a helper function that calculates directory hashes.
+* Changes OpenAPI specifications with respect to sign-up form.
+* Changes OpenAPI specifications with respect to email confirmation.
+* Changes CI system to include Python flake8 checker.
 
 ## 0.7.1 (2020-11-09)
 
-- Adds support for restarting yadage workflows (through `accept_metadir` operational option).
-- Allows `htcondor_max_runtime` and `htcondor_accounting_group` to be specified for HTC jobs.
-- Adds new field in REANA-Server OpenAPI spec to return server version.
-- Changes CI system from Travis to GitHub Actions.
+* Adds support for restarting yadage workflows (through `accept_metadir` operational option).
+* Allows `htcondor_max_runtime` and `htcondor_accounting_group` to be specified for HTC jobs.
+* Adds new field in REANA-Server OpenAPI spec to return server version.
+* Changes CI system from Travis to GitHub Actions.
 
 ## 0.7.0 (2020-10-20)
 
-- Adds new utility to send emails.
-- Adds centralised validation utility for workflow operational options.
-- Adds new configuration variable to set the maximum number of running workflows. (`REANA_MAX_CONCURRENT_BATCH_WORKFLOWS`)
-- Adds new configuration variable to set prefix of REANA cluster component names. (`REANA_COMPONENT_PREFIX`)
-- Adds new configuration variable for the runtime pod node selector label. (`REANA_RUNTIME_KUBERNETES_NODE_LABEL`)
-- Adds new configuration variable to define the Kubernetes namespace in which REANA infrastructure components run. (`REANA_INFRASTRUCTURE_KUBERNETES_NAMESPACE`)
-- Adds new configuration variable to define the Kubernetes namespace in which REANA runtime components components run. (`REANA_RUNTIME_KUBERNETES_NAMESPACE`)
-- Adds possibility to specify unpacked container images for running jobs.
-- Adds support for `initfiles` operational option for the Yadage workflow engine.
-- Fixes memory leak in Bravado client instantiation.
-- Changes CephFS Persistent Volume Claim name. (`REANA_SHARED_PVC_NAME`)
-- Changes default logging level to `INFO`.
-- Changes default CVMFS volume list to include LHCb Gaudi related workflows.
-- Changes code formatting to respect `black` coding style.
-- Changes underlying requirements to use Kubernetes Python library version 11.
-- Changes underlying requirements to use latest CVMFS CSI driver version.
-- Changes documentation to single-page layout.
+* Adds new utility to send emails.
+* Adds centralised validation utility for workflow operational options.
+* Adds new configuration variable to set the maximum number of running workflows. (`REANA_MAX_CONCURRENT_BATCH_WORKFLOWS`)
+* Adds new configuration variable to set prefix of REANA cluster component names. (`REANA_COMPONENT_PREFIX`)
+* Adds new configuration variable for the runtime pod node selector label. (`REANA_RUNTIME_KUBERNETES_NODE_LABEL`)
+* Adds new configuration variable to define the Kubernetes namespace in which REANA infrastructure components run. (`REANA_INFRASTRUCTURE_KUBERNETES_NAMESPACE`)
+* Adds new configuration variable to define the Kubernetes namespace in which REANA runtime components components run. (`REANA_RUNTIME_KUBERNETES_NAMESPACE`)
+* Adds possibility to specify unpacked container images for running jobs.
+* Adds support for `initfiles` operational option for the Yadage workflow engine.
+* Fixes memory leak in Bravado client instantiation.
+* Changes CephFS Persistent Volume Claim name. (`REANA_SHARED_PVC_NAME`)
+* Changes default logging level to `INFO`.
+* Changes default CVMFS volume list to include LHCb Gaudi related workflows.
+* Changes code formatting to respect `black` coding style.
+* Changes underlying requirements to use Kubernetes Python library version 11.
+* Changes underlying requirements to use latest CVMFS CSI driver version.
+* Changes documentation to single-page layout.
 
 ## 0.6.1 (2020-05-25)
 
-- Upgrades Kubernetes Python client.
+* Upgrades Kubernetes Python client.
 
 ## 0.6.0 (2019-12-19)
 
-- Adds new API for Gitlab integration.
-- Adds new Kubernetes client API for ingresses.
-- Adds new APIs for management of user secrets.
-- Adds EOS storage Kubernetes configuration.
-- Adds HTCondor and Slurm compute backends.
-- Adds support for streaming file uploads.
-- Allows unpacked CVMFS and CMS open data volumes.
-- Adds Serial workflow step name and compute backend.
-- Adds support for Python 3.8.
+* Adds new API for Gitlab integration.
+* Adds new Kubernetes client API for ingresses.
+* Adds new APIs for management of user secrets.
+* Adds EOS storage Kubernetes configuration.
+* Adds HTCondor and Slurm compute backends.
+* Adds support for streaming file uploads.
+* Allows unpacked CVMFS and CMS open data volumes.
+* Adds Serial workflow step name and compute backend.
+* Adds support for Python 3.8.
 
 ## 0.5.0 (2019-04-16)
 
-- Centralises log level and log format configuration.
-- Adds new utility to inspect the disk usage on a given workspace.
+* Centralises log level and log format configuration.
+* Adds new utility to inspect the disk usage on a given workspace.
   (`get_workspace_disk_usage`)
-- Introduces the module to share Celery tasks accross REANA
+* Introduces the module to share Celery tasks accross REANA
   components. (`tasks.py`)
-- Introduces common Celery task to determine whether REANA can
+* Introduces common Celery task to determine whether REANA can
   execute new workflows depending on a set of conditions
   such as running job count. (`reana_ready`, `check_predefined_conditions`,
   `check_running_job_count`)
-- Allows the AMQP consumer to be configurable with multiple queues.
-- Introduces new queue for workflow submission. (`workflow-submission`)
-- Introduces new publisher for workflow submissions.
+* Allows the AMQP consumer to be configurable with multiple queues.
+* Introduces new queue for workflow submission. (`workflow-submission`)
+* Introduces new publisher for workflow submissions.
   (`WorkflowSubmissionPublisher`)
-- Centralises Kubernetes API client configuration and initialisation.
-- Adds Kubernetes specific configuration for CVMFS volumes as utils.
-- Introduces a new method, `copy_openapi_specs`, to automatically move
+* Centralises Kubernetes API client configuration and initialisation.
+* Adds Kubernetes specific configuration for CVMFS volumes as utils.
+* Introduces a new method, `copy_openapi_specs`, to automatically move
   validated OpenAPI specifications from components to REANA Commons
   `openapi_specifications` directory.
-- Centralises interactive session types.
-- Introduces central REANA errors through the `errors.py` module.
-- Skips SSL verification for all HTTPS requests performed with the
+* Centralises interactive session types.
+* Introduces central REANA errors through the `errors.py` module.
+* Skips SSL verification for all HTTPS requests performed with the
   `BaseAPIClient`.
 
 ## 0.4.0 (2018-11-06)
 
-- Aggregates OpenAPI specifications of REANA components.
-- Improves AMQP re-connection handling. Switches from `pika` to `kombu`.
-- Enhances test suite and increases code coverage.
-- Changes license to MIT.
+* Aggregates OpenAPI specifications of REANA components.
+* Improves AMQP re-connection handling. Switches from `pika` to `kombu`.
+* Enhances test suite and increases code coverage.
+* Changes license to MIT.
 
 ## 0.3.1 (2018-09-04)
 
-- Adds parameter expansion and validation utilities for parametrised Serial
+* Adds parameter expansion and validation utilities for parametrised Serial
   workflows.
 
 ## 0.3.0 (2018-08-10)
 
-- Initial public release.
-- Provides basic AMQP pub/sub methods for REANA components.
-- Utilities for caching used in different REANA components.
-- Click formatting helpers.
+* Initial public release.
+* Provides basic AMQP pub/sub methods for REANA components.
+* Utilities for caching used in different REANA components.
+* Click formatting helpers.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
-Bug reports, issues, feature requests, and other contributions are welcome. If you find
-a demonstrable problem that is caused by the REANA code, please:
+Bug reports, issues, feature requests, and other contributions are welcome.
+If you find a demonstrable problem that is caused by the REANA code, please:
 
 1. Search for [already reported problems](https://github.com/reanahub/reana-commons/issues).
 2. Check if the issue has been fixed or is still reproducible on the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,12 @@
 # Contributing
 
-Bug reports, issues, feature requests, and other contributions are welcome.
-If you find a demonstrable problem that is caused by the REANA code, please:
+Bug reports, issues, feature requests, and other contributions are welcome. If
+you find a demonstrable problem that is caused by the REANA code, please:
 
-1. Search for [already reported problems](https://github.com/reanahub/reana-commons/issues).
-2. Check if the issue has been fixed or is still reproducible on the
-   latest `master` branch.
+1. Search for
+   [already reported problems](https://github.com/reanahub/reana-commons/issues).
+2. Check if the issue has been fixed or is still reproducible on the latest
+   `master` branch.
 3. Create an issue, ideally with **a test case**.
 
 If you create a pull request fixing a bug or implementing a feature, you can run

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,6 +11,7 @@ include *.toml
 include *.yaml
 include *.yml
 include .dockerignore
+include .editorconfig
 include .flake8
 include LICENSE
 include pytest.ini

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -13,6 +13,8 @@ include *.yml
 include .dockerignore
 include .editorconfig
 include .flake8
+include .prettierignore
+include .prettierrc.yaml
 include LICENSE
 include pytest.ini
 include tox.ini

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 ## About
 
 REANA-Commons is a component of the [REANA](http://www.reana.io/) reusable and
-reproducible research data analysis platform. It provides common utilities and schemas
-shared by the REANA cluster components.
+reproducible research data analysis platform. It provides common utilities and
+schemas shared by the REANA cluster components.
 
 ## Features
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,6 @@
+<!-- markdownlint-disable MD041 -->
+<!-- markdownlint-disable MD033 -->
+
 ```{include} ../README.md
 :end-before: "## About"
 ```

--- a/reana_commons/openapi_specifications/reana_job_controller.json
+++ b/reana_commons/openapi_specifications/reana_job_controller.json
@@ -171,9 +171,7 @@
             "type": "string"
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Request succeeded. Returns boolean depicting if job is in cache.",
@@ -198,9 +196,7 @@
       "get": {
         "description": "This resource is not expecting parameters and it will return a list representing all active jobs in JSON format.",
         "operationId": "get_jobs",
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Request succeeded. The response contains the list of all active jobs.",
@@ -209,10 +205,7 @@
                 "jobs": {
                   "1612a779-f3fa-4344-8819-3d12fa9b9d90": {
                     "cmd": "date",
-                    "cvmfs_mounts": [
-                      "atlas.cern.ch",
-                      "atlas-condb.cern.ch"
-                    ],
+                    "cvmfs_mounts": ["atlas.cern.ch", "atlas-condb.cern.ch"],
                     "docker_img": "docker.io/library/busybox",
                     "job_id": "1612a779-f3fa-4344-8819-3d12fa9b9d90",
                     "max_restart_count": 3,
@@ -221,10 +214,7 @@
                   },
                   "2e4bbc1d-db5e-4ee0-9701-6e2b1ba55c20": {
                     "cmd": "date",
-                    "cvmfs_mounts": [
-                      "atlas.cern.ch",
-                      "atlas-condb.cern.ch"
-                    ],
+                    "cvmfs_mounts": ["atlas.cern.ch", "atlas-condb.cern.ch"],
                     "docker_img": "docker.io/library/busybox",
                     "job_id": "2e4bbc1d-db5e-4ee0-9701-6e2b1ba55c20",
                     "max_restart_count": 3,
@@ -245,9 +235,7 @@
         "summary": "Returns list of all active jobs."
       },
       "post": {
-        "consumes": [
-          "application/json"
-        ],
+        "consumes": ["application/json"],
         "description": "This resource is expecting JSON data with all the necessary information of a new job.",
         "operationId": "create_job",
         "parameters": [
@@ -261,9 +249,7 @@
             }
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "201": {
             "description": "Request succeeded. The job has been launched.",
@@ -304,9 +290,7 @@
             "type": "string"
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Request succeeded. The response contains details about the given job ID.",
@@ -314,10 +298,7 @@
               "application/json": {
                 "job": {
                   "cmd": "date",
-                  "cvmfs_mounts": [
-                    "atlas.cern.ch",
-                    "atlas-condb.cern.ch"
-                  ],
+                  "cvmfs_mounts": ["atlas.cern.ch", "atlas-condb.cern.ch"],
                   "docker_img": "docker.io/library/busybox",
                   "job_id": "cdcf48b1-c2f3-4693-8230-b066e088c6ac",
                   "max_restart_count": 3,
@@ -344,9 +325,7 @@
     },
     "/jobs/{job_id}/": {
       "delete": {
-        "consumes": [
-          "application/json"
-        ],
+        "consumes": ["application/json"],
         "description": "This resource expects the `job_id` of the job to be deleted.",
         "operationId": "delete_job",
         "parameters": [
@@ -365,9 +344,7 @@
             "type": "string"
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "204": {
             "description": "Request accepted. A request to delete the job has been sent to the\n  compute backend."
@@ -405,9 +382,7 @@
             "type": "string"
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Request succeeded. The response contains the logs for the given job.",
@@ -431,14 +406,10 @@
     },
     "/shutdown": {
       "delete": {
-        "consumes": [
-          "application/json"
-        ],
+        "consumes": ["application/json"],
         "description": "All running jobs will be stopped and no more jobs will be scheduled. Kubernetes will call this endpoint before stopping the pod (PreStop hook).",
         "operationId": "shutdown",
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Request successful. All jobs were stopped.",

--- a/reana_commons/openapi_specifications/reana_server.json
+++ b/reana_commons/openapi_specifications/reana_server.json
@@ -20,9 +20,7 @@
             "type": "string"
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Configuration information to consume by Reana-UI.",
@@ -68,10 +66,7 @@
       "get": {
         "description": "Authorize REANA on GitLab.",
         "operationId": "gitlab_oauth",
-        "produces": [
-          "application/json",
-          "text/html"
-        ],
+        "produces": ["application/json", "text/html"],
         "responses": {
           "200": {
             "description": "Ping succeeded.",
@@ -174,9 +169,7 @@
             "type": "integer"
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "This resource return all projects owned by the user on GitLab in JSON format.",
@@ -282,17 +275,12 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "project_id",
-                "hook_id"
-              ],
+              "required": ["project_id", "hook_id"],
               "type": "object"
             }
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "204": {
             "description": "The webhook was properly deleted."
@@ -350,16 +338,12 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "project_id"
-              ],
+              "required": ["project_id"],
               "type": "object"
             }
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "201": {
             "description": "The webhook was created."
@@ -413,9 +397,7 @@
             "type": "string"
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Request succeeded. The response contains general info about the cluster.",
@@ -423,11 +405,7 @@
               "application/json": {
                 "compute_backends": {
                   "title": "List of supported compute backends",
-                  "value": [
-                    "kubernetes",
-                    "htcondorcern",
-                    "slurmcern"
-                  ]
+                  "value": ["kubernetes", "htcondorcern", "slurmcern"]
                 },
                 "cwl_engine_tool": {
                   "title": "CWL engine tool",
@@ -542,20 +520,11 @@
                 },
                 "supported_workflow_engines": {
                   "title": "List of supported workflow engines",
-                  "value": [
-                    "cwl",
-                    "serial",
-                    "snakemake",
-                    "yadage"
-                  ]
+                  "value": ["cwl", "serial", "snakemake", "yadage"]
                 },
                 "workspaces_available": {
                   "title": "List of available workspaces",
-                  "value": [
-                    "/usr/share",
-                    "/eos/home",
-                    "/var/reana"
-                  ]
+                  "value": ["/usr/share", "/eos/home", "/var/reana"]
                 },
                 "yadage_engine_adage_version": {
                   "title": "Yadage engine adage version",
@@ -995,9 +964,7 @@
     },
     "/api/launch": {
       "post": {
-        "consumes": [
-          "application/json"
-        ],
+        "consumes": ["application/json"],
         "description": "This resource expects a remote reference to a REANA specification file needed to launch a workflow via URL.",
         "operationId": "launch",
         "parameters": [
@@ -1024,16 +991,12 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "url"
-              ],
+              "required": ["url"],
               "type": "object"
             }
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Request succeeded. Information of the workflow launched.",
@@ -1068,11 +1031,7 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "workflow_id",
-                "workflow_name",
-                "message"
-              ],
+              "required": ["workflow_id", "workflow_name", "message"],
               "type": "object"
             }
           },
@@ -1116,9 +1075,7 @@
       "get": {
         "description": "Ping the server.",
         "operationId": "ping",
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Ping succeeded. Service is running and accessible.",
@@ -1157,9 +1114,7 @@
             "type": "string"
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "List of user secrets.",
@@ -1184,10 +1139,7 @@
                   },
                   "type": {
                     "description": "How will be the secret assigned to the jobs, either exported as an environment variable or mounted as a file.",
-                    "enum": [
-                      "env",
-                      "file"
-                    ],
+                    "enum": ["env", "file"],
                     "type": "string"
                   }
                 }
@@ -1258,17 +1210,12 @@
             }
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Secrets successfully deleted.",
             "examples": {
-              "application/json": [
-                ".keytab",
-                "username"
-              ]
+              "application/json": [".keytab", "username"]
             },
             "schema": {
               "description": "List of secret names that have been deleted.",
@@ -1298,10 +1245,7 @@
           "404": {
             "description": "Request failed. Secrets do not exist.",
             "examples": {
-              "application/json": [
-                "certificate.pem",
-                "PASSWORD"
-              ]
+              "application/json": ["certificate.pem", "PASSWORD"]
             },
             "schema": {
               "description": "List of secret names that could not be deleted.",
@@ -1360,10 +1304,7 @@
                 "properties": {
                   "type": {
                     "description": "How will be the secret assigned to the jobs, either exported as an environment variable or mounted as a file.",
-                    "enum": [
-                      "env",
-                      "file"
-                    ],
+                    "enum": ["env", "file"],
                     "type": "string"
                   },
                   "value": {
@@ -1377,9 +1318,7 @@
             }
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "201": {
             "description": "Secrets successfully added.",
@@ -1453,9 +1392,7 @@
       "get": {
         "description": "Retrieve cluster health status.",
         "operationId": "status",
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Cluster health status information.",
@@ -1622,9 +1559,7 @@
             "type": "string"
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "User information correspoding to the session cookie sent in the request.",
@@ -1718,9 +1653,7 @@
             "type": "string"
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Users that shared workflow(s) with the authenticated user.",
@@ -1815,9 +1748,7 @@
             "type": "string"
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Users that the authenticated user shared workflow(s) with.",
@@ -2004,9 +1935,7 @@
             "type": "string"
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Request succeeded. The response contains the list of all workflows.",
@@ -2272,9 +2201,7 @@
         "summary": "Returns list of all current workflows in REANA."
       },
       "post": {
-        "consumes": [
-          "application/json"
-        ],
+        "consumes": ["application/json"],
         "description": "This resource is expecting a REANA specification in JSON format with all the necessary information to instantiate a workflow.",
         "operationId": "create_workflow",
         "parameters": [
@@ -2309,9 +2236,7 @@
             "type": "string"
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "201": {
             "description": "Request succeeded. The workflow has been created.",
@@ -2410,9 +2335,7 @@
     },
     "/api/workflows/move_files/{workflow_id_or_name}": {
       "put": {
-        "consumes": [
-          "application/json"
-        ],
+        "consumes": ["application/json"],
         "description": "This resource moves files within the workspace. Resource is expecting a workflow UUID.",
         "operationId": "move_files",
         "parameters": [
@@ -2445,9 +2368,7 @@
             "type": "string"
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Request succeeded. Message about successfully moved files is returned.",
@@ -2600,17 +2521,13 @@
             "type": "string"
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Request succeeded. Info about a workflow, including the status is returned.",
             "examples": {
               "application/json": {
-                "reana_specification": [
-                  "- nevents: 100000\n+ nevents: 200000"
-                ],
+                "reana_specification": ["- nevents: 100000\n+ nevents: 200000"],
                 "workspace_listing": {
                   "Only in workspace a: code": null
                 }
@@ -2698,9 +2615,7 @@
     },
     "/api/workflows/{workflow_id_or_name}/close/": {
       "post": {
-        "consumes": [
-          "application/json"
-        ],
+        "consumes": ["application/json"],
         "description": "This resource is expecting a workflow to close an interactive session within its workspace.",
         "operationId": "close_interactive_session",
         "parameters": [
@@ -2719,9 +2634,7 @@
             "type": "string"
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Request succeeded. The interactive session has been closed.",
@@ -2844,9 +2757,7 @@
             }
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Request succeeded. Info about the disk usage is returned.",
@@ -3025,9 +2936,7 @@
             "type": "integer"
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Request succeeded. Info about a workflow, including the status is returned.",
@@ -3131,9 +3040,7 @@
     },
     "/api/workflows/{workflow_id_or_name}/open/{interactive_session_type}": {
       "post": {
-        "consumes": [
-          "application/json"
-        ],
+        "consumes": ["application/json"],
         "description": "This resource is expecting a workflow to start an interactive session within its workspace.",
         "operationId": "open_interactive_session",
         "parameters": [
@@ -3174,9 +3081,7 @@
             }
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Request succeeded. The interactive session has been opened.",
@@ -3282,9 +3187,7 @@
             "type": "string"
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Request succeeded. Workflow input parameters, including the status are returned.",
@@ -3422,9 +3325,7 @@
             "type": "boolean"
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Request succeeded. The workspace has been pruned.",
@@ -3538,9 +3439,7 @@
             "type": "string"
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Request succeeded. The response contains the list of all the retention rules.",
@@ -3702,16 +3601,12 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "user_email_to_share_with"
-              ],
+              "required": ["user_email_to_share_with"],
               "type": "object"
             }
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Request succeeded. The workflow has been shared with the user.",
@@ -3852,9 +3747,7 @@
             "type": "string"
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Request succeeded. The response contains the share status of the workflow.",
@@ -3985,9 +3878,7 @@
             "type": "string"
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Request succeeded. Workflow specification is returned.",
@@ -3996,10 +3887,7 @@
                 "parameters": {},
                 "specification": {
                   "inputs": {
-                    "files": [
-                      "code/helloworld.py",
-                      "data/names.txt"
-                    ],
+                    "files": ["code/helloworld.py", "data/names.txt"],
                     "parameters": {
                       "helloworld": "code/helloworld.py",
                       "inputfile": "data/names.txt",
@@ -4008,9 +3896,7 @@
                     }
                   },
                   "outputs": {
-                    "files": [
-                      "results/greetings.txt"
-                    ]
+                    "files": ["results/greetings.txt"]
                   },
                   "version": "0.3.0",
                   "workflow": {
@@ -4163,9 +4049,7 @@
     },
     "/api/workflows/{workflow_id_or_name}/start": {
       "post": {
-        "consumes": [
-          "application/json"
-        ],
+        "consumes": ["application/json"],
         "description": "This resource starts the workflow execution process. Resource is expecting a workflow UUID.",
         "operationId": "start_workflow",
         "parameters": [
@@ -4211,9 +4095,7 @@
             }
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Request succeeded. Info about a workflow, including the execution status is returned.",
@@ -4367,9 +4249,7 @@
             "type": "string"
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Request succeeded. Info about a workflow, including the status is returned.",
@@ -4577,9 +4457,7 @@
         "summary": "Get status of a workflow."
       },
       "put": {
-        "consumes": [
-          "application/json"
-        ],
+        "consumes": ["application/json"],
         "description": "This resource reports the status of a workflow. Resource is expecting a workflow UUID.",
         "operationId": "set_workflow_status",
         "parameters": [
@@ -4592,11 +4470,7 @@
           },
           {
             "description": "Required. New workflow status.",
-            "enum": [
-              "start",
-              "stop",
-              "deleted"
-            ],
+            "enum": ["start", "stop", "deleted"],
             "in": "query",
             "name": "status",
             "required": true,
@@ -4641,9 +4515,7 @@
             }
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Request succeeded. Info about a workflow, including the status is returned.",
@@ -4804,9 +4676,7 @@
             "type": "string"
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Request succeeded. The workflow has been unshared with the user.",
@@ -4964,9 +4834,7 @@
             "type": "string"
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Requests succeeded. The list of files has been retrieved.",
@@ -5072,9 +4940,7 @@
         "summary": "Returns the workspace file list."
       },
       "post": {
-        "consumes": [
-          "application/octet-stream"
-        ],
+        "consumes": ["application/octet-stream"],
         "description": "This resource is expecting a file to place in the workspace.",
         "operationId": "upload_file",
         "parameters": [
@@ -5116,9 +4982,7 @@
             "type": "boolean"
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Request succeeded. File successfully transferred.",
@@ -5226,9 +5090,7 @@
             "type": "string"
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Request succeeded. Details about deleted files and failed deletions are returned.",
@@ -5427,9 +5289,7 @@
             "type": "string"
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "User information correspoding to the session cookie sent in the request.",

--- a/reana_commons/openapi_specifications/reana_workflow_controller.json
+++ b/reana_commons/openapi_specifications/reana_workflow_controller.json
@@ -112,9 +112,7 @@
             "type": "string"
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Requests succeeded. The response contains the current workflows for a given user.",
@@ -324,9 +322,7 @@
             }
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "201": {
             "description": "Request succeeded. The workflow has been created along with its workspace",
@@ -369,9 +365,7 @@
     },
     "/api/workflows/move_files/{workflow_id_or_name}": {
       "put": {
-        "consumes": [
-          "application/json"
-        ],
+        "consumes": ["application/json"],
         "description": "This resource moves files within the workspace. Resource is expecting a workflow UUID.",
         "operationId": "move_files",
         "parameters": [
@@ -404,9 +398,7 @@
             "type": "string"
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Request succeeded. Message about successfully moved files is returned.",
@@ -506,17 +498,13 @@
             "type": "string"
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Request succeeded. Info about a workflow, including the status is returned.",
             "examples": {
               "application/json": {
-                "reana_specification": [
-                  "- nevents: 100000\n+ nevents: 200000"
-                ],
+                "reana_specification": ["- nevents: 100000\n+ nevents: 200000"],
                 "workspace_listing": {
                   "Only in workspace a: code": null
                 }
@@ -567,9 +555,7 @@
     },
     "/api/workflows/{workflow_id_or_name}/close": {
       "post": {
-        "consumes": [
-          "application/json"
-        ],
+        "consumes": ["application/json"],
         "description": "This resource is expecting a workflow to close an interactive session within its workspace.",
         "operationId": "close_interactive_session",
         "parameters": [
@@ -588,9 +574,7 @@
             "type": "string"
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Request succeeded. The interactive session has been closed.",
@@ -679,9 +663,7 @@
             "type": "integer"
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Request succeeded. Info about workflow, including the status is returned.",
@@ -740,9 +722,7 @@
     },
     "/api/workflows/{workflow_id_or_name}/open/{interactive_session_type}": {
       "post": {
-        "consumes": [
-          "application/json"
-        ],
+        "consumes": ["application/json"],
         "description": "This resource is expecting a workflow to start an interactive session within its workspace.",
         "operationId": "open_interactive_session",
         "parameters": [
@@ -783,9 +763,7 @@
             }
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Request succeeded. The interactive session has been opened.",
@@ -846,9 +824,7 @@
             "type": "string"
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Request succeeded. Workflow input parameters, including the status are returned.",
@@ -934,9 +910,7 @@
             "type": "string"
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Request succeeded. The response contains the list of all the retention rules.",
@@ -1066,16 +1040,12 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "user_email_to_share_with"
-              ],
+              "required": ["user_email_to_share_with"],
               "type": "object"
             }
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Request succeeded. The workflow has been shared with the user.",
@@ -1152,9 +1122,7 @@
             "type": "string"
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Request succeeded. The response contains the share status of the workflow.",
@@ -1253,9 +1221,7 @@
             "type": "string"
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Request succeeded. Info about workflow, including the status is returned.",
@@ -1345,11 +1311,7 @@
           },
           {
             "description": "Required. New status.",
-            "enum": [
-              "start",
-              "stop",
-              "deleted"
-            ],
+            "enum": ["start", "stop", "deleted"],
             "in": "query",
             "name": "status",
             "required": true,
@@ -1387,9 +1349,7 @@
             }
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Request succeeded. Info about workflow, including the status is returned.",
@@ -1505,9 +1465,7 @@
             "type": "string"
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Request succeeded. The workflow has been unshared with the user.",
@@ -1665,9 +1623,7 @@
             "type": "string"
           }
         ],
-        "produces": [
-          "multipart/form-data"
-        ],
+        "produces": ["multipart/form-data"],
         "responses": {
           "200": {
             "description": "Requests succeeded. The list of code|input|output files has been retrieved.",
@@ -1728,9 +1684,7 @@
         "summary": "Returns the workspace file list."
       },
       "post": {
-        "consumes": [
-          "application/octet-stream"
-        ],
+        "consumes": ["application/octet-stream"],
         "description": "This resource is expecting a workflow UUID and a file to place in the workspace.",
         "operationId": "upload_file",
         "parameters": [
@@ -1765,9 +1719,7 @@
             "type": "string"
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Request succeeded. The file has been added to the workspace.",
@@ -1838,9 +1790,7 @@
             "type": "string"
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "Request succeeded. Details about deleted files and failed deletions are returned.",

--- a/reana_commons/validation/schemas/reana_analysis_schema.json
+++ b/reana_commons/validation/schemas/reana_analysis_schema.json
@@ -5,9 +5,7 @@
   "type": "object",
   "title": "REANA analysis specification",
   "description": "Full analysis specification including data, sofware, environment and workflow enabling reproducibility on a REANA cluster.",
-  "required": [
-    "workflow"
-  ],
+  "required": ["workflow"],
   "additionalProperties": false,
   "properties": {
     "version": {
@@ -80,12 +78,7 @@
           "type": "string",
           "title": "Workflow engine.",
           "description": "Name which represents a supported workflow engine to be used to reproduce the analysis.",
-          "enum": [
-            "cwl",
-            "serial",
-            "yadage",
-            "snakemake"
-          ]
+          "enum": ["cwl", "serial", "yadage", "snakemake"]
         },
         "resources": {
           "$id": "/properties/workflow/properties/resources",
@@ -124,24 +117,24 @@
               "type": "object",
               "title": "Information about Dask cluster requested for the analysis.",
               "properties": {
-              "image": {
-                "type": "string",
-                "description": "Container image to be used by Dask scheduler and workers.",
-                "pattern": "^(?:[a-zA-Z0-9.-]+(?:\\.[a-zA-Z0-9.-]+)+(?::[0-9]+)?/)?[a-zA-Z0-9._-]+(?:/[a-zA-Z0-9._-]+)*(?::[a-zA-Z0-9._-]+)?(?:@sha256:[a-f0-9]{64})?$"
-              },
-              "number_of_workers": {
-                "type": "integer",
-                "description": "Requested number of Dask workers."
-              },
-              "single_worker_memory": {
-                "type": "string",
-                "description": "Requested memory for one Dask worker.",
-                "pattern": "^[1-9][0-9]*(Ei|Pi|Ti|Gi|Mi|Ki|E|P|T|G|M|K)$"
-              },
-              "single_worker_threads": {
-                "type": "integer",
-                "description": "Requested number of threads for one Dask worker."
-              }
+                "image": {
+                  "type": "string",
+                  "description": "Container image to be used by Dask scheduler and workers.",
+                  "pattern": "^(?:[a-zA-Z0-9.-]+(?:\\.[a-zA-Z0-9.-]+)+(?::[0-9]+)?/)?[a-zA-Z0-9._-]+(?:/[a-zA-Z0-9._-]+)*(?::[a-zA-Z0-9._-]+)?(?:@sha256:[a-f0-9]{64})?$"
+                },
+                "number_of_workers": {
+                  "type": "integer",
+                  "description": "Requested number of Dask workers."
+                },
+                "single_worker_memory": {
+                  "type": "string",
+                  "description": "Requested memory for one Dask worker.",
+                  "pattern": "^[1-9][0-9]*(Ei|Pi|Ti|Gi|Mi|Ki|E|P|T|G|M|K)$"
+                },
+                "single_worker_threads": {
+                  "type": "integer",
+                  "description": "Requested number of threads for one Dask worker."
+                }
               },
               "required": ["image"]
             }
@@ -151,16 +144,10 @@
       },
       "anyOf": [
         {
-          "required": [
-            "type",
-            "file"
-          ]
+          "required": ["type", "file"]
         },
         {
-          "required": [
-            "type",
-            "specification"
-          ]
+          "required": ["type", "specification"]
         }
       ]
     },
@@ -280,12 +267,12 @@
                     },
                     "compute_backend": {
                       "type": "string",
-                        "enum": [
-                          "kubernetes",
-                          "htcondorcern",
-                          "slurmcern",
-                          "compute4punch"
-                        ],
+                      "enum": [
+                        "kubernetes",
+                        "htcondorcern",
+                        "slurmcern",
+                        "compute4punch"
+                      ],
                       "title": "Compute backend"
                     },
                     "environment": {
@@ -366,10 +353,7 @@
                       "description": "Additional HTCondor requirements like RequestGPUs for running the task."
                     }
                   },
-                  "required": [
-                    "commands",
-                    "environment"
-                  ]
+                  "required": ["commands", "environment"]
                 }
               }
             }

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # This file is part of REANA.
-# Copyright (C) 2018, 2020, 2021, 2024 CERN.
+# Copyright (C) 2018, 2020, 2021, 2024, 2025 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -9,11 +9,23 @@
 set -o errexit
 set -o nounset
 
-check_commitlint () {
+docs_sphinx() {
+    sphinx-build -qnNW docs docs/_build/html
+}
+
+format_black() {
+    black --check .
+}
+
+lint_commitlint() {
     from=${2:-master}
     to=${3:-HEAD}
     pr=${4:-[0-9]+}
-    npx commitlint --from="$from" --to="$to"
+    if command -v commitlint > /dev/null 2>&1; then
+        commitlint --from="$from" --to="$to"
+    else
+        npx commitlint --from="$from" --to="$to"
+    fi
     found=0
     while IFS= read -r line; do
         commit_hash=$(echo "$line" | cut -d ' ' -f 1)
@@ -31,7 +43,7 @@ check_commitlint () {
         # (iii) check absence of merge commits in feature branches
         if [ "$commit_number_of_parents" -gt 1 ]; then
             if echo "$commit_title" | grep -qE "^chore\(.*\): merge "; then
-                break  # skip checking maint-to-master merge commits
+                break # skip checking maint-to-master merge commits
             else
                 echo "✖   Merge commits are not allowed in feature branches: $commit_title"
                 found=1
@@ -43,59 +55,68 @@ check_commitlint () {
     fi
 }
 
-check_shellcheck () {
-    find . -name "*.sh" -exec shellcheck {} \+
-}
-
-check_pydocstyle () {
-    pydocstyle reana_commons
-}
-
-check_black () {
-    black --check .
-}
-
-check_flake8 () {
+lint_flake8() {
     flake8 .
 }
 
-check_manifest () {
+lint_manifest() {
     check-manifest
 }
 
-check_sphinx () {
-    sphinx-build -qnNW docs docs/_build/html
+lint_pydocstyle() {
+    pydocstyle reana_commons
 }
 
-check_pytest () {
+lint_shellcheck() {
+    find . -name "*.sh" -exec shellcheck {} \+
+}
+
+python_tests() {
     pytest
 }
 
-check_all () {
-    check_commitlint
-    check_shellcheck
-    check_pydocstyle
-    check_black
-    check_flake8
-    check_manifest
-    check_sphinx
-    check_pytest
+all() {
+    docs_sphinx
+    format_black
+    lint_commitlint
+    lint_flake8
+    lint_manifest
+    lint_pydocstyle
+    lint_shellcheck
+    python_tests
+}
+
+help() {
+    echo "Usage: $0 [options]"
+    echo "Options:"
+    echo "  --all                Perform all checks [default]"
+    echo "  --docs-sphinx        Check Sphinx docs build"
+    echo "  --format-black       Check formatting of Python code"
+    echo "  --help               Display this help message"
+    echo "  --lint-commitlint    Check linting of commit messages"
+    echo "  --lint-flake8        Check linting of Python code"
+    echo "  --lint-manifest      Check linting of Python manifest"
+    echo "  --lint-pydocstyle    Check linting of Python docstrings"
+    echo "  --lint-shellcheck    Check linting of shell scripts"
+    echo "  --python-tests       Check Python test suite"
 }
 
 if [ $# -eq 0 ]; then
-    check_all
+    all
     exit 0
 fi
 
 arg="$1"
 case $arg in
-    --check-commitlint) check_commitlint "$@";;
-    --check-shellcheck) check_shellcheck;;
-    --check-pydocstyle) check_pydocstyle;;
-    --check-black) check_black;;
-    --check-flake8) check_flake8;;
-    --check-manifest) check_manifest;;
-    --check-sphinx) check_sphinx;;
-    --check-pytest) check_pytest;;
-    *) echo "[ERROR] Invalid argument '$arg'. Exiting." && exit 1;;
+--all) all ;;
+--help) help ;;
+--docs-sphinx) docs_sphinx ;;
+--format-black) format_black ;;
+--lint-commitlint) lint_commitlint "$@" ;;
+--lint-flake8) lint_flake8 ;;
+--lint-manifest) lint_manifest ;;
+--lint-pydocstyle) lint_pydocstyle ;;
+--lint-shellcheck) lint_shellcheck ;;
+--python-tests) python_tests ;;
+*) echo "[ERROR] Invalid argument '$arg'. Exiting." && help && exit 1 ;;
 esac

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -71,6 +71,10 @@ lint_manifest() {
     check-manifest
 }
 
+lint_markdownlint() {
+    markdownlint-cli2 "**/*.md"
+}
+
 lint_pydocstyle() {
     pydocstyle reana_commons
 }
@@ -95,6 +99,7 @@ all() {
     lint_flake8
     lint_jsonlint
     lint_manifest
+    lint_markdownlint
     lint_pydocstyle
     lint_shellcheck
     lint_yamllint
@@ -113,6 +118,7 @@ help() {
     echo "  --lint-flake8        Check linting of Python code"
     echo "  --lint-jsonlint      Check linting of JSON files"
     echo "  --lint-manifest      Check linting of Python manifest"
+    echo "  --lint-markdownlint  Check linting of Markdown files"
     echo "  --lint-pydocstyle    Check linting of Python docstrings"
     echo "  --lint-shellcheck    Check linting of shell scripts"
     echo "  --lint-yamllint      Check linting of YAML files"
@@ -135,6 +141,7 @@ case $arg in
 --lint-flake8) lint_flake8 ;;
 --lint-jsonlint) lint_jsonlint ;;
 --lint-manifest) lint_manifest ;;
+--lint-markdownlint) lint_markdownlint ;;
 --lint-pydocstyle) lint_pydocstyle ;;
 --lint-shellcheck) lint_shellcheck ;;
 --lint-yamllint) lint_yamllint ;;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -17,11 +17,15 @@ format_black() {
     black --check .
 }
 
+format_shfmt() {
+    shfmt -d .
+}
+
 lint_commitlint() {
     from=${2:-master}
     to=${3:-HEAD}
     pr=${4:-[0-9]+}
-    if command -v commitlint > /dev/null 2>&1; then
+    if command -v commitlint >/dev/null 2>&1; then
         commitlint --from="$from" --to="$to"
     else
         npx commitlint --from="$from" --to="$to"
@@ -86,6 +90,7 @@ python_tests() {
 all() {
     docs_sphinx
     format_black
+    format_shfmt
     lint_commitlint
     lint_flake8
     lint_jsonlint
@@ -102,6 +107,7 @@ help() {
     echo "  --all                Perform all checks [default]"
     echo "  --docs-sphinx        Check Sphinx docs build"
     echo "  --format-black       Check formatting of Python code"
+    echo "  --format-shfmt       Check formatting of shell scripts"
     echo "  --help               Display this help message"
     echo "  --lint-commitlint    Check linting of commit messages"
     echo "  --lint-flake8        Check linting of Python code"
@@ -124,6 +130,7 @@ case $arg in
 --help) help ;;
 --docs-sphinx) docs_sphinx ;;
 --format-black) format_black ;;
+--format-shfmt) format_shfmt ;;
 --lint-commitlint) lint_commitlint "$@" ;;
 --lint-flake8) lint_flake8 ;;
 --lint-jsonlint) lint_jsonlint ;;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -59,6 +59,10 @@ lint_flake8() {
     flake8 .
 }
 
+lint_jsonlint() {
+    find . -name "*.json" -exec jsonlint -q {} \+
+}
+
 lint_manifest() {
     check-manifest
 }
@@ -80,6 +84,7 @@ all() {
     format_black
     lint_commitlint
     lint_flake8
+    lint_jsonlint
     lint_manifest
     lint_pydocstyle
     lint_shellcheck
@@ -95,6 +100,7 @@ help() {
     echo "  --help               Display this help message"
     echo "  --lint-commitlint    Check linting of commit messages"
     echo "  --lint-flake8        Check linting of Python code"
+    echo "  --lint-jsonlint      Check linting of JSON files"
     echo "  --lint-manifest      Check linting of Python manifest"
     echo "  --lint-pydocstyle    Check linting of Python docstrings"
     echo "  --lint-shellcheck    Check linting of shell scripts"
@@ -114,6 +120,7 @@ case $arg in
 --format-black) format_black ;;
 --lint-commitlint) lint_commitlint "$@" ;;
 --lint-flake8) lint_flake8 ;;
+--lint-jsonlint) lint_jsonlint ;;
 --lint-manifest) lint_manifest ;;
 --lint-pydocstyle) lint_pydocstyle ;;
 --lint-shellcheck) lint_shellcheck ;;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -17,6 +17,10 @@ format_black() {
     black --check .
 }
 
+format_prettier() {
+    prettier -c .
+}
+
 format_shfmt() {
     shfmt -d .
 }
@@ -94,6 +98,7 @@ python_tests() {
 all() {
     docs_sphinx
     format_black
+    format_prettier
     format_shfmt
     lint_commitlint
     lint_flake8
@@ -112,6 +117,7 @@ help() {
     echo "  --all                Perform all checks [default]"
     echo "  --docs-sphinx        Check Sphinx docs build"
     echo "  --format-black       Check formatting of Python code"
+    echo "  --format-prettier    Check formatting of Markdown etc files"
     echo "  --format-shfmt       Check formatting of shell scripts"
     echo "  --help               Display this help message"
     echo "  --lint-commitlint    Check linting of commit messages"
@@ -136,6 +142,7 @@ case $arg in
 --help) help ;;
 --docs-sphinx) docs_sphinx ;;
 --format-black) format_black ;;
+--format-prettier) format_prettier ;;
 --format-shfmt) format_shfmt ;;
 --lint-commitlint) lint_commitlint "$@" ;;
 --lint-flake8) lint_flake8 ;;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -75,6 +75,10 @@ lint_shellcheck() {
     find . -name "*.sh" -exec shellcheck {} \+
 }
 
+lint_yamllint() {
+    yamllint .
+}
+
 python_tests() {
     pytest
 }
@@ -88,6 +92,7 @@ all() {
     lint_manifest
     lint_pydocstyle
     lint_shellcheck
+    lint_yamllint
     python_tests
 }
 
@@ -104,6 +109,7 @@ help() {
     echo "  --lint-manifest      Check linting of Python manifest"
     echo "  --lint-pydocstyle    Check linting of Python docstrings"
     echo "  --lint-shellcheck    Check linting of shell scripts"
+    echo "  --lint-yamllint      Check linting of YAML files"
     echo "  --python-tests       Check Python test suite"
 }
 
@@ -124,6 +130,7 @@ case $arg in
 --lint-manifest) lint_manifest ;;
 --lint-pydocstyle) lint_pydocstyle ;;
 --lint-shellcheck) lint_shellcheck ;;
+--lint-yamllint) lint_yamllint ;;
 --python-tests) python_tests ;;
 *) echo "[ERROR] Invalid argument '$arg'. Exiting." && help && exit 1 ;;
 esac


### PR DESCRIPTION
- Refactors `run-tests.sh` to add usage help, standardise function naming, and improve option handling.
- Adds new linter and formatter checks where applicable (yamllint, shfmt, markdownlint, prettier, jsonlint).
- Updates `.github/workflows/ci.yml` with corresponding CI jobs.