### PR TITLE
build(python): bump kubernetes lower pin to 23.6.0

### DIFF
--- a/reana_commons/version.py
+++ b/reana_commons/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.95.0a13"
+__version__ = "0.95.0a14"

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ extras_require = {
         "pytest-reana>=0.95.0a7,<0.96.0",
     ],
     "kubernetes": [
-        "kubernetes>=22.0.0,<27.0.0",  # upper pin due to oauthlib 3.x incompatibility with reana-server invenio packages
+        "kubernetes>=23.6.0,<27.0.0",  # upper pin due to oauthlib 3.x incompatibility with reana-server invenio packages
         "google-auth<2.46.0; python_version<'3.9'",
     ],
     "yadage": [


### PR DESCRIPTION
Bump the lower pin from 22.0.0 to 23.6.0 to ensure the `V1LifecycleHandler` class is always available, as it replaced the deprecated `V1Handler`.