### PR TITLE
Fix/snakemake lambda params in wildcards

### DIFF
--- a/reana_commons/snakemake.py
+++ b/reana_commons/snakemake.py
@@ -274,7 +274,10 @@ def snakemake_load_v7(workflow_file: str, **kwargs: Any):
                 "name": rule.name,
                 "environment": (rule._container_img or "").replace("docker://", ""),
                 "inputs": dict(rule._input),
-                "params": dict(rule._params),
+                "params": {
+                    k: "<dynamic>" if callable(v) else v
+                    for k, v in dict(rule._params).items()
+                },
                 "outputs": dict(rule._output),
                 "commands": [rule.shellcmd],
                 "compute_backend": rule.resources.get("compute_backend"),

--- a/reana_commons/version.py
+++ b/reana_commons/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.95.0a14"
+__version__ = "0.95.0a15"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,6 +64,30 @@ rule baz:
 
 
 @pytest.fixture()
+def dummy_snakefile_with_lambda_param():
+    """Get dummy Snakemake specification with a lambda param value."""
+    return """
+rule all:
+    input:
+        "results/out.txt",
+    default_target: True
+
+rule make_out:
+    input:
+        "input.txt"
+    output:
+        "results/out.txt"
+    params:
+        static_param="hello",
+        dynamic_param=lambda wildcards: "computed"
+    container:
+        "docker://docker.io/library/python:3.10.0-buster"
+    shell:
+        "mkdir -p results && touch {output}"
+"""
+
+
+@pytest.fixture()
 def mock_data_fetcher():
     """Mock data fetcher for gherkin_parser tests."""
     mock_data_fetcher = create_autospec(DataFetcherBase)

--- a/tests/test_snakemake.py
+++ b/tests/test_snakemake.py
@@ -46,3 +46,31 @@ def test_snakemake_load(tmpdir, dummy_snakefile):
         "baz": ["foo", "bar"],
         "all": ["foo", "bar", "baz"],
     }
+
+
+@pytest.mark.xfail(
+    sys.version_info >= (3, 11),
+    reason="Test expected to fail for python versions 3.11 and above as we currently return only empty dictionary in snakemake_load function for python >= 3.11.",
+)
+def test_snakemake_load_lambda_params_are_json_serializable(
+    tmpdir, dummy_snakefile_with_lambda_param
+):
+    """Test that lambda param values are replaced with '<dynamic>' and JSON-serializable."""
+    import json
+
+    workdir = tmpdir.mkdir("sub")
+    p = workdir.join("Snakefile")
+    p.write(dummy_snakefile_with_lambda_param)
+    dummy_input = workdir.join("input.txt")
+    dummy_input.write("Content of input.txt")
+
+    os.chdir(tmpdir)
+    metadata = snakemake_load(Path(p.strpath), workdir=Path(workdir.strpath))
+
+    # Must not raise
+    json.dumps(metadata)
+
+    make_out_step = next(s for s in metadata["steps"] if s["name"] == "make_out")
+    assert "dynamic_param" in make_out_step["params"]
+    assert make_out_step["params"]["dynamic_param"] == "<dynamic>"
+    assert make_out_step["params"]["static_param"] == "hello"


### PR DESCRIPTION
## Problem

Fixes reanahub/reana-client#729.

Snakemake allows lambda functions as `params` values, documented language feature used for wildcard-dependent dynamic parameters:

```python
rule myrule:
    params:
        threshold = lambda wildcards: get_threshold(wildcards.sample)
    shell:
        "process.py --threshold {params.threshold}"
```
In `snakemake_load_v7()`, rule-level params are collected as:

```python
"params": dict(rule._params),
```

At rule-definition time, `rule._params` stores the raw lambda object for callable params. This dict is included in `reana_yaml["workflow"]["specification"]`, which is then passed to `json.dumps()` in `reana_client`. This crashes at workflow submission time with:

```bash
TypeError: Object of type function is not JSON serializable
==> ERROR: Cannot create workflow test:
Object of type function is not JSON serializable
```

Any Snakemake workflow using lambda params — which is extremely common for wildcard-dependent per-sample parameterization — hits this bug and cannot be submitted.

## Root cause

`rule._params` is the rule-level (pre-wildcard-resolution) params object. Callable values are only resolved at job execution time, after wildcards are substituted. REANA collects rule metadata before execution, so it will always see the raw callable
for lambda params.

## Fix

Replace callable values with the sentinel string `"<dynamic>"` when building the params dict:

```python
"params": {
    k: "<dynamic>" if callable(v) else v
    for k, v in dict(rule._params).items()
},
```

This is safe because the only downstream consumer of params values is `reana_commons/validation/parameters.py`, which calls `step.get("params", {}).keys()`. It only needs the key names to validate `{params.foo}` references in shell commands, never the values.

## Testing

Added a new fixture `dummy_snakefile_with_lambda_param` and test `test_snakemake_load_lambda_params_are_json_serializable` that verifies:

* `json.dumps(metadata)` does not raise
* Lambda param key is present with value `"<dynamic>"`
* Static param values are preserved unchanged

The test is marked `xfail` for Python >= 3.11 consistent with the existing test, since `snakemake_load_v8` is a separate code path.

## Notes

* Only `snakemake_load_v7` is affected (Python < 3.11 path)
* `snakemake_load_v8` is a separate issue (currently returns empty stubs)
* `_input` and `_output` are not changed, callables are far less common there and not confirmed to cause issues.