### PR TITLE
build(python): remove kubernetes upper version pin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ extras_require = {
         "pytest-reana>=0.95.0a7,<0.96.0",
     ],
     "kubernetes": [
-        "kubernetes>=23.6.0,<27.0.0",  # upper pin due to oauthlib 3.x incompatibility with reana-server invenio packages
+        "kubernetes>=23.6.0",
         "google-auth<2.46.0; python_version<'3.9'",
     ],
     "yadage": [


### PR DESCRIPTION
The kubernetes<27.0.0 upper pin was in place because kubernetes >=27 requires oauthlib>=3.x, which conflicted with the old Invenio packages used by reana-server (they required oauthlib<3.0.0 via flask-oauthlib).

Now that reana-server is being upgraded to the latest Invenio packages (which use flask-oauthlib-invenio and support oauthlib 3.x), this upper pin is no longer needed.

Closes reanahub/reana-server#770.