### PR TITLE
feat(openapi): sync bundled specs with components

### DIFF
--- a/reana_commons/openapi_specifications/reana_job_controller.json
+++ b/reana_commons/openapi_specifications/reana_job_controller.json
@@ -1,6 +1,7 @@
 {
   "definitions": {
     "Job": {
+      "additionalProperties": false,
       "properties": {
         "cmd": {
           "type": "string"
@@ -16,11 +17,9 @@
           "type": "string"
         },
         "max_restart_count": {
-          "format": "int32",
           "type": "integer"
         },
         "restart_count": {
-          "format": "int32",
           "type": "integer"
         },
         "status": {
@@ -38,6 +37,7 @@
       "type": "object"
     },
     "JobRequest": {
+      "additionalProperties": false,
       "properties": {
         "c4p_additional_requirements": {
           "type": "string"
@@ -63,6 +63,7 @@
           "type": "string"
         },
         "env_vars": {
+          "additionalProperties": {},
           "default": {},
           "type": "object"
         },
@@ -85,7 +86,6 @@
           "type": "string"
         },
         "kubernetes_job_timeout": {
-          "format": "int32",
           "type": "integer"
         },
         "kubernetes_memory_limit": {
@@ -95,7 +95,6 @@
           "type": "string"
         },
         "kubernetes_uid": {
-          "format": "int32",
           "type": "integer"
         },
         "prettified_cmd": {
@@ -140,7 +139,7 @@
   "info": {
     "description": "REANA Job Controller API",
     "title": "reana-job-controller",
-    "version": "0.95.0a3"
+    "version": "0.95.0a4"
   },
   "paths": {
     "/apispec": {},

--- a/reana_commons/openapi_specifications/reana_server.json
+++ b/reana_commons/openapi_specifications/reana_server.json
@@ -5267,7 +5267,7 @@
             "type": "integer"
           },
           {
-            "description": "Filter workflow workspace files.",
+            "description": "Filter workflow workspace files by file name, size, or modification date.",
             "in": "query",
             "name": "search",
             "required": false,
@@ -5315,10 +5315,10 @@
             }
           },
           "400": {
-            "description": "Request failed. The incoming payload seems malformed.",
+            "description": "Request failed. The request parameters are invalid or the filtered result set exceeds the configured display limit.",
             "examples": {
               "application/json": {
-                "message": "Field 'size': Must be at least 1."
+                "message": "Too many files to display (e.g. limit=100000). Please use more specific filters to narrow the results. Available filters: file name, size, or last-modified."
               }
             },
             "schema": {

--- a/reana_commons/openapi_specifications/reana_workflow_controller.json
+++ b/reana_commons/openapi_specifications/reana_workflow_controller.json
@@ -2,7 +2,7 @@
   "info": {
     "description": "Submit and manage workflows",
     "title": "REANA Workflow Controller",
-    "version": "0.95.0a5"
+    "version": "0.95.0a6"
   },
   "paths": {
     "/api/workflows": {
@@ -1658,7 +1658,7 @@
             "type": "integer"
           },
           {
-            "description": "Filter workflow workspace files.",
+            "description": "Filter workflow workspace files by file name, size, or modification date.",
             "in": "query",
             "name": "search",
             "required": false,
@@ -1706,7 +1706,7 @@
             }
           },
           "400": {
-            "description": "Request failed. The incoming data specification seems malformed."
+            "description": "Request failed. The request parameters are invalid or the filtered result set exceeds the configured display limit."
           },
           "404": {
             "description": "Request failed. Workflow does not exist.",


### PR DESCRIPTION
Refresh the bundled `reana_server`, `reana_workflow_controller` and `reana_job_controller` OpenAPI specs from the component repos, mostly to absorb the marshmallow 3 / apispec output changes introduced by the Flask 3.x and SQLAlchemy 2.x upgrade.