### PR TITLE
test(api-client): use mock.Mock to match cache isinstance check (#526)

### DIFF
--- a/reana_commons/testing/api_client.py
+++ b/reana_commons/testing/api_client.py
@@ -10,7 +10,7 @@
 
 from __future__ import absolute_import, print_function
 
-from unittest.mock import Mock
+from mock import Mock
 
 from reana_commons.api_client import BaseAPIClient
 


### PR DESCRIPTION
The BaseAPIClient singleton cache uses `isinstance(http_client, Mock)` with `Mock` from the third-party `mock` package to decide whether to reinstantiate the bravado client between calls. When `make_mock_api_client` creates `unittest.mock.Mock` instances instead, that isinstance check returns False and the cache is never invalidated: subsequent tests inherit a previously-installed mock client and the real API path is never exercised.

Import `Mock` from the same package as `BaseAPIClient` so the cache-busting path matches.