### PR TITLE
feat(openapi): add info on Kubernetes job user ID minimum

### DIFF
--- a/reana_commons/api_client.py
+++ b/reana_commons/api_client.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2018, 2019, 2020, 2021, 2022, 2025 CERN.
+# Copyright (C) 2018, 2019, 2020, 2021, 2022, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -140,7 +140,7 @@ class JobControllerAPIClient(BaseAPIClient):
         :param voms_proxy: Decides if grid proxy should be provided for job
             container.
         :param rucio: Decides if a rucio environment should be provided for job.
-        :param kubernetes_uid: Overwrites the default user id in the job container.
+        :param kubernetes_uid: Overwrites the default UID in the job container.
         :param kubernetes_memory_limit: Overwrites the default memory limit in the job container.
         :param unpacked_img: Decides if unpacked iamges should be used.
         :param htcondor_max_runtime: Maximum runtime of a HTCondor job.
@@ -176,7 +176,7 @@ class JobControllerAPIClient(BaseAPIClient):
         if rucio:
             job_spec["rucio"] = rucio
 
-        if kubernetes_uid:
+        if kubernetes_uid is not None:
             job_spec["kubernetes_uid"] = kubernetes_uid
 
         if kubernetes_cpu_request:

--- a/reana_commons/errors.py
+++ b/reana_commons/errors.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2018, 2019, 2020, 2021, 2022, 2025 CERN.
+# Copyright (C) 2018, 2019, 2020, 2021, 2022, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -99,6 +99,14 @@ class REANAKubernetesCPULimitExceeded(Exception):
 
     def __init__(self, message):
         """Initialize REANAKubernetesCPULimitExceeded exception."""
+        self.message = message
+
+
+class REANAKubernetesUIDBelowMinimum(Exception):
+    """Kubernetes UID is below the cluster-configured minimum."""
+
+    def __init__(self, message):
+        """Initialize REANAKubernetesUIDBelowMinimum exception."""
         self.message = message
 
 

--- a/reana_commons/openapi_specifications/reana_job_controller.json
+++ b/reana_commons/openapi_specifications/reana_job_controller.json
@@ -283,6 +283,17 @@
           "400": {
             "description": "Request failed. The incoming data specification seems malformed."
           },
+          "403": {
+            "description": "Request failed. The job submission was refused, e.g. because a requested resource (CPU, memory, UID) violates the cluster-configured limits.",
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
           "500": {
             "description": "Request failed. Internal controller error. The job could probably not have been allocated."
           }

--- a/reana_commons/openapi_specifications/reana_server.json
+++ b/reana_commons/openapi_specifications/reana_server.json
@@ -528,6 +528,10 @@
                   "title": "Default memory request for Kubernetes jobs",
                   "value": "1Gi"
                 },
+                "kubernetes_min_user_uid": {
+                  "title": "Minimum allowed user runtime container UID for Kubernetes jobs",
+                  "value": 100
+                },
                 "maximum_kubernetes_jobs_timeout": {
                   "title": "Maximum timeout for Kubernetes jobs",
                   "value": "1209600"
@@ -858,6 +862,17 @@
                     "value": {
                       "type": "string",
                       "x-nullable": true
+                    }
+                  },
+                  "type": "object"
+                },
+                "kubernetes_min_user_uid": {
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "integer"
                     }
                   },
                   "type": "object"

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2026 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""REANA-Commons API client tests."""
+
+from unittest import mock
+
+import pytest
+
+from reana_commons.api_client import JobControllerAPIClient
+
+
+def _make_client():
+    """Build a ``JobControllerAPIClient`` with a mocked Bravado backend."""
+    client = JobControllerAPIClient.__new__(JobControllerAPIClient)
+    client._client = mock.MagicMock()
+    client._client.jobs.create_job.return_value.result.return_value = (
+        {"job_id": "x"},
+        mock.Mock(status_code=200),
+    )
+    return client
+
+
+@pytest.mark.parametrize(
+    "kubernetes_uid,expected_in_spec",
+    [
+        (0, True),  # Root must reach job-controller so it can refuse it.
+        (50, True),  # Below-minimum UIDs must reach job-controller too.
+        (1000, True),  # Regular UIDs are forwarded.
+        (None, False),  # No UID requested: omitted from the request.
+    ],
+)
+def test_submit_forwards_kubernetes_uid(kubernetes_uid, expected_in_spec):
+    """``kubernetes_uid`` must be forwarded even when zero or below minimum.
+
+    Previously the API client used a truthy check, silently dropping UID 0
+    before job-controller could refuse it. The check now uses ``is not None``
+    so that the configurable minimum-UID guard is honoured for every
+    explicit value.
+    """
+    client = _make_client()
+    client.submit(image="busybox", cmd="ls", kubernetes_uid=kubernetes_uid)
+    job_spec = client._client.jobs.create_job.call_args.kwargs["job"]
+    if expected_in_spec:
+        assert job_spec["kubernetes_uid"] == kubernetes_uid
+    else:
+        assert "kubernetes_uid" not in job_spec


### PR DESCRIPTION
Add the `kubernetes_min_user_uid` field to the reana-server `/info` OpenAPI response schema and example, mirroring the new field exposed by reana-server.

Also add a new `REANAKubernetesUIDBelowMinimum` exception that reana-job-controller raises when a workflow declares a `kubernetes_uid` smaller than the cluster-configured minimum, surfaced to the user via a clear error message.

Fix the truthy `if kubernetes_uid:` check in
`JobControllerAPIClient.submit` so that an explicit `kubernetes_uid: 0` is forwarded to job-controller instead of being silently dropped. Without this, workflow engines would never propagate UID 0 (root) to the new minimum-UID guard and the request would fall back to the runtime default. Cover the regression with a parametrised test.

Closes reanahub/reana#951