### PR TITLE
fix(schema): accept unpacked_img as serial step property

### DIFF
--- a/reana_commons/serial.py
+++ b/reana_commons/serial.py
@@ -42,6 +42,11 @@ serial_workflow_schema = {
                         "$id": "#/properties/steps/properties/environment",
                         "type": "string",
                     },
+                    "unpacked_img": {
+                        "$id": "#/properties/steps/properties/unpacked_img",
+                        "type": "boolean",
+                        "default": "false",
+                    },
                     "unpacked_image": {
                         "$id": "#/properties/steps/properties/unpacked_image",
                         "type": "boolean",


### PR DESCRIPTION
The CWL, Snakemake and Yadage engines, and the cross-engine
analysis schema, all use `unpacked_img` for unpacked Singularity
images on CVMFS. Only the serial schema accepted `unpacked_image`.
A workflow with `unpacked_img: true` therefore passed top-level
validation but was silently dropped by the serial engine, while
`unpacked_image: true` worked at runtime yet triggered validation
warnings.

Accept `unpacked_img` here so the four engines stay in sync. The
legacy `unpacked_image` key is kept alongside it for one release
cycle to avoid breaking existing serial workflows.

Closes #530