### PR TITLE
feat(k8s): set explicit runAsNonRoot on Kerberos sidecars 

### DIFF
--- a/reana_commons/k8s/kerberos.py
+++ b/reana_commons/k8s/kerberos.py
@@ -104,7 +104,7 @@ def get_kerberos_k8s_config(
         "imagePullPolicy": "IfNotPresent",
         "volumeMounts": [secrets_volume_mount] + volume_mounts,
         "env": env,
-        "securityContext": {"runAsUser": kubernetes_uid},
+        "securityContext": {"runAsUser": kubernetes_uid, "runAsNonRoot": True},
     }
 
     # Kerberos renew container renews ticket periodically for long-running jobs
@@ -127,7 +127,7 @@ def get_kerberos_k8s_config(
         "imagePullPolicy": "IfNotPresent",
         "volumeMounts": [secrets_volume_mount] + volume_mounts,
         "env": env,
-        "securityContext": {"runAsUser": kubernetes_uid},
+        "securityContext": {"runAsUser": kubernetes_uid, "runAsNonRoot": True},
         "lifecycle": {
             # make sure we stop the sidecar container when the pod is stopped,
             # for example when the run-batch pod is terminated by reana-workflow-controller

--- a/tests/k8s/test_kerberos.py
+++ b/tests/k8s/test_kerberos.py
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2024 CERN.
+# Copyright (C) 2024, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -25,4 +25,6 @@ def test_get_kerberos_k8s_config(kerberos_user_secrets):
         "johndoe@CERN.CH",
     ]
     assert conf.init_container["securityContext"]["runAsUser"] == 123
+    assert conf.init_container["securityContext"]["runAsNonRoot"] is True
     assert conf.renew_container["securityContext"]["runAsUser"] == 123
+    assert conf.renew_container["securityContext"]["runAsNonRoot"] is True


### PR DESCRIPTION
Set `runAsNonRoot: true` on both the Kerberos init and renew container security contexts so Kubernetes refuses to schedule the pod if a future caller would pass `kubernetes_uid=0`. Today, no caller does; this is just a defence-in-depth change at the cluster layer, complementing already-existing application-level UID guards in place.