### PR TITLE
feat(scheduler): add workflow_uses_kubernetes utility and publisher flag

### DIFF
--- a/reana_commons/config.py
+++ b/reana_commons/config.py
@@ -255,6 +255,11 @@ REANA_MAX_CONCURRENT_BATCH_WORKFLOWS = int(
 )
 """Upper limit on concurrent REANA batch workflows running in the cluster."""
 
+REANA_MAX_CONCURRENT_EXTERNAL_BATCH_WORKFLOWS = int(
+    os.getenv("REANA_MAX_CONCURRENT_EXTERNAL_BATCH_WORKFLOWS", "200")
+)
+"""Upper limit on concurrent REANA batch workflows running on external compute backends (e.g. HTCondor, Slurm)."""
+
 REANA_LOG_LEVEL = logging.getLevelName(os.getenv("REANA_LOG_LEVEL", "INFO"))
 """Log verbosity level for REANA components."""
 

--- a/reana_commons/publisher.py
+++ b/reana_commons/publisher.py
@@ -170,6 +170,7 @@ class WorkflowSubmissionPublisher(BasePublisher):
         parameters,
         priority=0,
         min_job_memory=0,
+        uses_kubernetes=True,
         retry_count: Optional[int] = None,
     ):
         """Publish workflow submission parameters."""
@@ -179,6 +180,7 @@ class WorkflowSubmissionPublisher(BasePublisher):
             "parameters": parameters,
             "priority": priority,
             "min_job_memory": min_job_memory,
+            "uses_kubernetes": uses_kubernetes,
         }
 
         if retry_count:

--- a/reana_commons/validation/compute_backends.py
+++ b/reana_commons/validation/compute_backends.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2022 CERN.
+# Copyright (C) 2022, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -11,6 +11,75 @@
 from typing import Dict, List, Optional
 
 from reana_commons.errors import REANAValidationError
+
+
+def workflow_uses_kubernetes(reana_yaml: Dict) -> bool:
+    """Check if any step in the workflow runs on Kubernetes.
+
+    Steps that do not declare a compute backend default to Kubernetes.
+    Hybrid workflows (some steps on Kubernetes, some on HTCondor/Slurm) also
+    return True.
+    """
+    workflow = reana_yaml.get("workflow", {})
+    workflow_type = workflow.get("type")
+    spec = workflow.get("specification", {})
+
+    if workflow_type == "serial":
+        return _serial_uses_kubernetes(spec)
+    if workflow_type == "snakemake":
+        return _snakemake_uses_kubernetes(spec)
+    if workflow_type == "yadage":
+        return _yadage_uses_kubernetes(spec.get("stages", []))
+    if workflow_type == "cwl":
+        graph = spec.get("$graph", spec)
+        return _cwl_uses_kubernetes(graph)
+    return True  # unknown type: conservative default
+
+
+def _serial_uses_kubernetes(spec: Dict) -> bool:
+    steps = spec.get("steps", [])
+    return any(
+        step.get("compute_backend", "kubernetes") == "kubernetes" for step in steps
+    )
+
+
+def _snakemake_uses_kubernetes(spec: Dict) -> bool:
+    return _serial_uses_kubernetes(spec)
+
+
+def _yadage_uses_kubernetes(stages: List[Dict]) -> bool:
+    for stage in stages:
+        scheduler = stage.get("scheduler", {})
+        if "workflow" in scheduler:
+            if _yadage_uses_kubernetes(scheduler["workflow"].get("stages", [])):
+                return True
+        else:
+            resources = (
+                scheduler.get("step", {}).get("environment", {}).get("resources", [])
+            )
+            backend = next(
+                (r["compute_backend"] for r in resources if "compute_backend" in r),
+                "kubernetes",
+            )
+            if backend == "kubernetes":
+                return True
+    return False
+
+
+def _cwl_uses_kubernetes(workflow) -> bool:
+    def _check(wf: Dict) -> bool:
+        for step in wf.get("steps", []):
+            hints = step.get("hints", [])
+            reana_hints = next((h for h in hints if h.get("class") == "reana"), {})
+            if reana_hints.get("compute_backend", "kubernetes") == "kubernetes":
+                return True
+        return False
+
+    if isinstance(workflow, dict):
+        return _check(workflow)
+    if isinstance(workflow, list):
+        return any(_check(wf) for wf in workflow)
+    return True
 
 
 def build_compute_backends_validator(

--- a/tests/test_compute_backends.py
+++ b/tests/test_compute_backends.py
@@ -1,0 +1,171 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2026 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Tests for compute backend utilities."""
+
+import pytest
+
+from reana_commons.validation.compute_backends import workflow_uses_kubernetes
+
+
+def _serial_spec(steps):
+    return {"workflow": {"type": "serial", "specification": {"steps": steps}}}
+
+
+def _snakemake_spec(steps):
+    return {"workflow": {"type": "snakemake", "specification": {"steps": steps}}}
+
+
+def _yadage_spec(stages):
+    return {"workflow": {"type": "yadage", "specification": {"stages": stages}}}
+
+
+def _cwl_spec(steps, as_list=False):
+    graph = {"steps": steps}
+    if as_list:
+        graph = [graph]
+    return {"workflow": {"type": "cwl", "specification": {"$graph": graph}}}
+
+
+def _yadage_stage(name, backend=None):
+    resources = [{"compute_backend": backend}] if backend else []
+    return {
+        "name": name,
+        "scheduler": {
+            "step": {"environment": {"resources": resources}},
+        },
+    }
+
+
+def _cwl_step(name, backend=None):
+    hints = []
+    if backend is not None:
+        hints = [{"class": "reana", "compute_backend": backend}]
+    return {"id": name, "hints": hints}
+
+
+# --- serial ---
+
+
+@pytest.mark.parametrize(
+    "steps, expected",
+    [
+        ([{"name": "step1"}], True),  # no backend -> assumes kubernetes used
+        ([{"name": "step1", "compute_backend": "kubernetes"}], True),
+        ([{"name": "step1", "compute_backend": "htcondor"}], False),
+        ([{"name": "step1", "compute_backend": "slurm"}], False),
+        (
+            [
+                {"name": "step1", "compute_backend": "htcondor"},
+                {"name": "step2"},  # no backend -> counts as using kubernetes
+            ],
+            True,  # hybrid workflow
+        ),
+        (
+            [
+                {"name": "step1", "compute_backend": "htcondor"},
+                {"name": "step2", "compute_backend": "slurm"},
+            ],
+            False,  # non-kubernetes workflow
+        ),
+        ([], False),  # no steps -> non-kubernetes workflow
+    ],
+)
+def test_serial_workflow_uses_kubernetes(steps, expected):
+    assert workflow_uses_kubernetes(_serial_spec(steps)) is expected
+
+
+# --- snakemake ---
+
+
+@pytest.mark.parametrize(
+    "steps, expected",
+    [
+        ([{"name": "step1"}], True),
+        ([{"name": "step1", "compute_backend": "htcondor"}], False),
+        (
+            [
+                {"name": "step1", "compute_backend": "htcondor"},
+                {"name": "step2", "compute_backend": "kubernetes"},
+            ],
+            True,
+        ),
+    ],
+)
+def test_snakemake_workflow_uses_kubernetes(steps, expected):
+    assert workflow_uses_kubernetes(_snakemake_spec(steps)) is expected
+
+
+# --- yadage ---
+
+
+@pytest.mark.parametrize(
+    "stages, expected",
+    [
+        ([_yadage_stage("s1")], True),  # no backend -> assumes kubernetes used
+        ([_yadage_stage("s1", "kubernetes")], True),
+        ([_yadage_stage("s1", "htcondor")], False),
+        ([_yadage_stage("s1", "slurm")], False),
+        (
+            [_yadage_stage("s1", "htcondor"), _yadage_stage("s2")],
+            True,
+        ),  # hybrid workflow
+        ([_yadage_stage("s1", "htcondor"), _yadage_stage("s2", "slurm")], False),
+        ([], False),
+    ],
+)
+def test_yadage_workflow_uses_kubernetes(stages, expected):
+    assert workflow_uses_kubernetes(_yadage_spec(stages)) is expected
+
+
+def test_yadage_nested_workflow_uses_kubernetes():
+    """Nested yadage workflows are recursively checked."""
+    nested_stage = _yadage_stage("inner", "htcondor")
+    outer_stage = {
+        "name": "outer",
+        "scheduler": {"workflow": {"stages": [nested_stage]}},
+    }
+    assert workflow_uses_kubernetes(_yadage_spec([outer_stage])) is False
+
+    nested_k8s = _yadage_stage("inner")  # defaults to kubernetes
+    outer_k8s = {
+        "name": "outer",
+        "scheduler": {"workflow": {"stages": [nested_k8s]}},
+    }
+    assert workflow_uses_kubernetes(_yadage_spec([outer_k8s])) is True
+
+
+# --- cwl ---
+
+
+@pytest.mark.parametrize(
+    "steps, as_list, expected",
+    [
+        ([_cwl_step("s1")], False, True),  # no backend -> assumes kubernetes used
+        ([_cwl_step("s1", "kubernetes")], False, True),
+        ([_cwl_step("s1", "htcondor")], False, False),
+        (
+            [_cwl_step("s1", "htcondor"), _cwl_step("s2")],
+            False,
+            True,
+        ),  # hybrid workflow
+        ([_cwl_step("s1", "htcondor")], True, False),  # list form
+        ([_cwl_step("s1")], True, True),
+        ([], False, False),
+    ],
+)
+def test_cwl_workflow_uses_kubernetes(steps, as_list, expected):
+    assert workflow_uses_kubernetes(_cwl_spec(steps, as_list=as_list)) is expected
+
+
+# --- unknown workflow type ---
+
+
+def test_unknown_workflow_type_defaults_to_kubernetes():
+    spec = {"workflow": {"type": "unknown_future_type", "specification": {}}}
+    assert workflow_uses_kubernetes(spec) is True


### PR DESCRIPTION
Adds functions to check if any workflow step runs on Kubernetes. Also adds uses_kubernetes to the WorkflowSubmissionPublisher message so the scheduler can skip the Kubernetes concurrency limit for non-Kubernetes workflows without an extra database query.