### PR TITLE
feat(schema): add HTCondor CPU/memory/disk/requirements hints

### DIFF
--- a/reana_commons/api_client.py
+++ b/reana_commons/api_client.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2018, 2019, 2020, 2021, 2022, 2025, 2026 CERN.
+# Copyright (C) 2018, 2019, 2020, 2021, 2022, 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -118,6 +118,10 @@ class JobControllerAPIClient(BaseAPIClient):
         rucio=False,
         htcondor_max_runtime="",
         htcondor_accounting_group="",
+        htcondor_request_cpus="",
+        htcondor_request_memory="",
+        htcondor_request_disk="",
+        htcondor_requirements="",
         slurm_partition="",
         slurm_time="",
         kubernetes_job_timeout: Optional[int] = None,
@@ -145,6 +149,19 @@ class JobControllerAPIClient(BaseAPIClient):
         :param unpacked_img: Decides if unpacked iamges should be used.
         :param htcondor_max_runtime: Maximum runtime of a HTCondor job.
         :param htcondor_accounting_group: Accounting group of a HTCondor job.
+        :param htcondor_request_cpus: Number of CPU cores requested for a
+            HTCondor job (positive integer as string, e.g. ``"4"``).
+        :param htcondor_request_memory: Memory requested for a HTCondor job.
+            Accepts a positive integer with an optional ``K|KB|M|MB|G|GB|T|TB``
+            suffix (case-insensitive, binary multipliers); the suffix-less
+            form is interpreted as megabytes. Examples: ``"4096"``, ``"4 GB"``.
+        :param htcondor_request_disk: Disk requested for a HTCondor job.
+            Same quantity syntax as ``htcondor_request_memory``; the
+            suffix-less form is interpreted as kilobytes. Examples:
+            ``"10000000"``, ``"10 GB"``.
+        :param htcondor_requirements: HTCondor ``Requirements`` ClassAd
+            expression used to select the execution machine, e.g.
+            ``'(Arch =?= "aarch64")'``.
         :param slurm_partition: Partition of a Slurm job.
         :param slurm_time: Maximum timelimit of a Slurm job.
         :param kubernetes_job_timeout: Timeout for the job in seconds.
@@ -202,6 +219,18 @@ class JobControllerAPIClient(BaseAPIClient):
 
         if htcondor_accounting_group:
             job_spec["htcondor_accounting_group"] = htcondor_accounting_group
+
+        if htcondor_request_cpus:
+            job_spec["htcondor_request_cpus"] = htcondor_request_cpus
+
+        if htcondor_request_memory:
+            job_spec["htcondor_request_memory"] = htcondor_request_memory
+
+        if htcondor_request_disk:
+            job_spec["htcondor_request_disk"] = htcondor_request_disk
+
+        if htcondor_requirements:
+            job_spec["htcondor_requirements"] = htcondor_requirements
 
         if slurm_partition:
             job_spec["slurm_partition"] = slurm_partition

--- a/reana_commons/openapi_specifications/reana_job_controller.json
+++ b/reana_commons/openapi_specifications/reana_job_controller.json
@@ -73,6 +73,18 @@
         "htcondor_max_runtime": {
           "type": "string"
         },
+        "htcondor_request_cpus": {
+          "type": "string"
+        },
+        "htcondor_request_disk": {
+          "type": "string"
+        },
+        "htcondor_request_memory": {
+          "type": "string"
+        },
+        "htcondor_requirements": {
+          "type": "string"
+        },
         "job_name": {
           "type": "string"
         },

--- a/reana_commons/serial.py
+++ b/reana_commons/serial.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2018, 2019, 2020, 2021, 2022 CERN.
+# Copyright (C) 2018, 2019, 2020, 2021, 2022, 2024, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 """REANA Workflow Engine Serial implementation utils."""
 
 import json
+import re
 from copy import deepcopy
 from string import Template
 
@@ -98,6 +99,26 @@ serial_workflow_schema = {
                         "type": "string",
                         "default": "",
                     },
+                    "htcondor_request_cpus": {
+                        "$id": "#/properties/steps/properties/htcondor_request_cpus",
+                        "type": "string",
+                        "default": "",
+                    },
+                    "htcondor_request_memory": {
+                        "$id": "#/properties/steps/properties/htcondor_request_memory",
+                        "type": "string",
+                        "default": "",
+                    },
+                    "htcondor_request_disk": {
+                        "$id": "#/properties/steps/properties/htcondor_request_disk",
+                        "type": "string",
+                        "default": "",
+                    },
+                    "htcondor_requirements": {
+                        "$id": "#/properties/steps/properties/htcondor_requirements",
+                        "type": "string",
+                        "default": "",
+                    },
                     "slurm_partition": {
                         "$id": "#/properties/steps/properties/slurm_partition",
                         "type": "string",
@@ -151,6 +172,9 @@ def serial_load(workflow_file, specification, parameters=None, original=None, **
     if not check_htcondor_max_runtime(specification):
         raise Exception("Invalid input in htcondor_max_runtime.")
 
+    if not check_htcondor_request_parameters(specification):
+        raise Exception("Invalid input in htcondor_request_* parameters.")
+
     parameters = parameters or {}
 
     if not specification:
@@ -197,6 +221,89 @@ def _expand_parameters(specification, parameters, original=None):
                 "be expanded. Please take a look "
                 "to {params}".format(params=str(e))
             )
+
+
+HTCONDOR_REQUEST_INTEGER_FIELDS = ("htcondor_request_cpus",)
+"""Step fields that must be a plain positive integer string."""
+
+HTCONDOR_REQUEST_QUANTITY_FIELDS = (
+    "htcondor_request_memory",
+    "htcondor_request_disk",
+)
+"""Step fields that accept a positive integer with an optional HTCondor
+unit suffix (``K|KB|M|MB|G|GB|T|TB``)."""
+
+HTCONDOR_QUANTITY_FORMAT = r"^[1-9]\d*\s*(K|KB|M|MB|G|GB|T|TB)?$"
+"""Regex mirroring the HTCondor submit-file quantity syntax accepted by
+reana-job-controller's ``htcondor_quantity_to_unit`` helper. Matched
+case-insensitively. Kept here as a string so it can also be referenced
+from JSON schemas. The authoritative conversion lives in
+reana-job-controller; this regex only fences off obviously bad input on
+the client side without pulling the htcondor/classad libraries into
+plain client environments."""
+
+_HTCONDOR_QUANTITY_RE = re.compile(HTCONDOR_QUANTITY_FORMAT, re.IGNORECASE)
+
+
+def check_htcondor_request_parameters(specification):
+    """Check the htcondor_request_* and htcondor_requirements step fields.
+
+    Validation here is intentionally lightweight:
+
+    * ``htcondor_request_cpus`` must be a positive integer string.
+    * ``htcondor_request_memory`` and ``htcondor_request_disk`` must be a
+      positive integer with an optional ``K|KB|M|MB|G|GB|T|TB`` suffix
+      (case-insensitive). The actual conversion to ``RequestMemory`` MB
+      or ``RequestDisk`` KB happens in reana-job-controller.
+    * ``htcondor_requirements`` must be a non-empty string. Authoritative
+      ClassAd parsing also happens in reana-job-controller to avoid
+      pulling the htcondor/classad libraries into ordinary client
+      environments.
+
+    :param specification: reana specification of workflow.
+    """
+    check_pass = True
+    for i, step in enumerate(specification["steps"]):
+        step_label = step.get("name", i)
+        for field in HTCONDOR_REQUEST_INTEGER_FIELDS:
+            value = step.get(field)
+            if not value:
+                continue
+            if not (isinstance(value, str) and value.isdigit() and int(value) > 0):
+                check_pass = False
+                click.secho(
+                    "In step {0}:\n'{1}' is not a valid input for {2}. "
+                    "It must be a positive integer in the form of a string.".format(
+                        step_label, value, field
+                    ),
+                    fg="red",
+                )
+        for field in HTCONDOR_REQUEST_QUANTITY_FIELDS:
+            value = step.get(field)
+            if not value:
+                continue
+            if not (isinstance(value, str) and _HTCONDOR_QUANTITY_RE.match(value)):
+                check_pass = False
+                click.secho(
+                    "In step {0}:\n'{1}' is not a valid input for {2}. "
+                    "It must be a positive integer with an optional "
+                    "K/KB/M/MB/G/GB/T/TB suffix (case-insensitive). "
+                    "Kubernetes-style Gi/Mi suffixes are not accepted.".format(
+                        step_label, value, field
+                    ),
+                    fg="red",
+                )
+        requirements = step.get("htcondor_requirements")
+        if requirements is not None and not (
+            isinstance(requirements, str) and requirements.strip()
+        ):
+            check_pass = False
+            click.secho(
+                "In step {0}:\nhtcondor_requirements must be a non-empty "
+                "string ClassAd expression.".format(step_label),
+                fg="red",
+            )
+    return check_pass
 
 
 def check_htcondor_max_runtime(specification):

--- a/reana_commons/validation/schemas/reana_analysis_schema.json
+++ b/reana_commons/validation/schemas/reana_analysis_schema.json
@@ -288,6 +288,26 @@
                       "type": "string",
                       "title": "HTCondor maximum runtime"
                     },
+                    "htcondor_request_cpus": {
+                      "type": "string",
+                      "title": "HTCondor request CPUs",
+                      "description": "Number of CPU cores to request from HTCondor for the step (positive integer as string, e.g. \"4\")."
+                    },
+                    "htcondor_request_memory": {
+                      "type": "string",
+                      "title": "HTCondor request memory",
+                      "description": "Amount of memory to request from HTCondor for the step. Accepts a positive integer with an optional K/KB/M/MB/G/GB/T/TB suffix (case-insensitive, binary multipliers); the suffix-less form is interpreted as megabytes. Examples: \"4000\", \"4 GB\". Kubernetes-style Gi/Mi suffixes are not accepted."
+                    },
+                    "htcondor_request_disk": {
+                      "type": "string",
+                      "title": "HTCondor request disk",
+                      "description": "Amount of disk to request from HTCondor for the step. Accepts a positive integer with an optional K/KB/M/MB/G/GB/T/TB suffix (case-insensitive, binary multipliers); the suffix-less form is interpreted as kilobytes. Examples: \"10000000\", \"10 GB\". Kubernetes-style Gi/Mi suffixes are not accepted."
+                    },
+                    "htcondor_requirements": {
+                      "type": "string",
+                      "title": "HTCondor requirements expression",
+                      "description": "HTCondor Requirements ClassAd expression used to select the execution machine, e.g. '(Arch =?= \"aarch64\")'."
+                    },
                     "kerberos": {
                       "type": "boolean",
                       "title": "Use Kerberos authentication",

--- a/tests/test_serial.py
+++ b/tests/test_serial.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2026 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Tests for REANA Commons Serial workflow validation helpers."""
+
+import pytest
+
+from reana_commons.serial import (
+    HTCONDOR_REQUEST_INTEGER_FIELDS,
+    HTCONDOR_REQUEST_QUANTITY_FIELDS,
+    check_htcondor_request_parameters,
+)
+
+
+def _spec(step):
+    return {"steps": [step]}
+
+
+# --- htcondor_request_cpus (positive integer string only) ---------------------
+
+
+@pytest.mark.parametrize("field", HTCONDOR_REQUEST_INTEGER_FIELDS)
+def test_htcondor_request_integer_field_accepts_positive_int_string(field):
+    """Positive integer strings pass the check for htcondor_request_cpus."""
+    assert check_htcondor_request_parameters(_spec({field: "4"})) is True
+
+
+@pytest.mark.parametrize("field", HTCONDOR_REQUEST_INTEGER_FIELDS)
+@pytest.mark.parametrize("bad_value", ["0", "-1", "1.5", "4 GB", "abc", " "])
+def test_htcondor_request_integer_field_rejects_invalid(field, bad_value):
+    """Non-positive-integer strings are rejected for htcondor_request_cpus."""
+    assert check_htcondor_request_parameters(_spec({field: bad_value})) is False
+
+
+@pytest.mark.parametrize("field", HTCONDOR_REQUEST_INTEGER_FIELDS)
+def test_htcondor_request_integer_field_absence_is_allowed(field):
+    """Omitting htcondor_request_cpus passes validation."""
+    assert check_htcondor_request_parameters(_spec({})) is True
+
+
+# --- htcondor_request_memory / htcondor_request_disk (quantity strings) -------
+
+
+@pytest.mark.parametrize("field", HTCONDOR_REQUEST_QUANTITY_FIELDS)
+@pytest.mark.parametrize(
+    "value",
+    ["4096", "4GB", "4 GB", "4 gb", "10TB", "10 TB"],
+)
+def test_htcondor_request_quantity_field_accepts_valid(field, value):
+    """Valid HTCondor quantity strings pass the check for memory/disk."""
+    assert check_htcondor_request_parameters(_spec({field: value})) is True
+
+
+@pytest.mark.parametrize("field", HTCONDOR_REQUEST_QUANTITY_FIELDS)
+@pytest.mark.parametrize(
+    "bad_value",
+    ["0", "-1", "1.5GB", "4Gi", "4 XB", "GB", " ", "abc"],
+)
+def test_htcondor_request_quantity_field_rejects_invalid(field, bad_value):
+    """Invalid quantity strings are rejected for memory/disk."""
+    assert check_htcondor_request_parameters(_spec({field: bad_value})) is False
+
+
+@pytest.mark.parametrize("field", HTCONDOR_REQUEST_QUANTITY_FIELDS)
+def test_htcondor_request_quantity_field_absence_is_allowed(field):
+    """Omitting a quantity field passes validation."""
+    assert check_htcondor_request_parameters(_spec({})) is True
+
+
+# --- htcondor_requirements ----------------------------------------------------
+
+
+def test_htcondor_requirements_accepts_non_empty_string():
+    """A non-empty string passes the htcondor_requirements check."""
+    assert (
+        check_htcondor_request_parameters(
+            _spec({"htcondor_requirements": '(Arch =?= "aarch64")'})
+        )
+        is True
+    )
+
+
+def test_htcondor_requirements_rejects_empty_string():
+    """An explicitly empty htcondor_requirements is rejected."""
+    assert (
+        check_htcondor_request_parameters(_spec({"htcondor_requirements": "   "}))
+        is False
+    )
+
+
+def test_htcondor_requirements_absence_is_allowed():
+    """Omitting htcondor_requirements passes validation."""
+    assert check_htcondor_request_parameters(_spec({})) is True
+
+
+def test_multiple_steps_all_validated():
+    """All steps are individually checked."""
+    spec = {
+        "steps": [
+            {"htcondor_request_cpus": "4"},
+            {"htcondor_request_memory": "1.5GB"},
+        ]
+    }
+    assert check_htcondor_request_parameters(spec) is False


### PR DESCRIPTION
Wires four new step parameters across the shared client library so
they can flow from reana.yaml to reana-job-controller:

* htcondor_request_cpus: positive integer string.
* htcondor_request_memory and htcondor_request_disk: positive integer
  with an optional K/KB/M/MB/G/GB/T/TB suffix (case-insensitive, binary
  multipliers); suffix-less forms are interpreted as megabytes and
  kilobytes respectively.
* htcondor_requirements: free ClassAd expression.

Validation in serial.py's check_htcondor_request_parameters is
intentionally lightweight (regex only); authoritative ClassAd parsing
stays in reana-job-controller so plain client environments do not need
the htcondor/classad libraries.

api_client.submit() gates each new kwarg on truthiness so unset values
do not reach the wire. The bundled OpenAPI spec is kept in sync with
reana-job-controller's docs/openapi.json.

Closes reanahub/reana-job-controller#502
