### PR TITLE
build(python): upgrade to Snakemake 9.22.0

### DIFF
--- a/reana_commons/config.py
+++ b/reana_commons/config.py
@@ -475,7 +475,7 @@ REANA_COMPUTE_BACKENDS = {
 REANA_WORKFLOW_ENGINES = ["yadage", "cwl", "serial", "snakemake"]
 """Available workflow engines."""
 
-REANA_DEFAULT_SNAKEMAKE_ENV_IMAGE = "docker.io/snakemake/snakemake:v9.16.3"
+REANA_DEFAULT_SNAKEMAKE_ENV_IMAGE = "docker.io/snakemake/snakemake:v9.22.0"
 """Snakemake default job environment image."""
 
 REANA_JOB_CONTROLLER_CONNECTION_CHECK_SLEEP = float(

--- a/setup.py
+++ b/setup.py
@@ -43,13 +43,13 @@ extras_require = {
     "snakemake": [
         "snakemake==7.32.4 ; python_version<'3.11'",
         "pulp>=2.7.0,<2.8.0 ; python_version<'3.11'",
-        "snakemake==9.16.3 ; python_version>='3.11'",
+        "snakemake==9.22.0 ; python_version>='3.11'",
     ],
     "snakemake-kubernetes": [
-        "snakemake-executor-plugin-kubernetes>=0.1.5 ; python_version>='3.11'",
+        "snakemake-executor-plugin-kubernetes>=0.5.1 ; python_version>='3.11'",
     ],
     "snakemake-xrootd": [
-        "snakemake-storage-plugin-xrootd==1.0.0 ; python_version>='3.11'",
+        "snakemake-storage-plugin-xrootd>=1.1.0 ; python_version>='3.11'",
     ],
 }
 


### PR DESCRIPTION
Bumps Snakemake from 9.16.3 to 9.22.0 on Python 3.11+.

Raises the minimum versions of "snakemake-kubernetes" and "snakemake-xrootd" extras to the latest releases.

Aligns the default Snakemake job environment image to 9.22.0.