### PR TITLE
fix(snakemake): validate workflow container images

### DIFF
--- a/reana_commons/snakemake.py
+++ b/reana_commons/snakemake.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2021, 2022, 2024 CERN.
+# Copyright (C) 2021, 2022, 2023, 2024, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -16,6 +16,7 @@ from pathlib import Path
 
 if sys.version_info >= (3, 11):
     from snakemake.api import SnakemakeApi
+    from snakemake.settings.enums import Quietness
     from snakemake.settings.types import (
         ResourceSettings,
         WorkflowSettings,
@@ -68,13 +69,16 @@ def snakemake_validate_v7(
     :param workdir: Path to working directory.
     :type workdir: string or None
     """
-    valid = snakemake(
-        snakefile=workflow_file,
-        configfiles=configfiles,
-        workdir=workdir,
-        dryrun=True,
-        quiet=True,
-    )
+    try:
+        valid = snakemake(
+            snakefile=workflow_file,
+            configfiles=configfiles,
+            workdir=workdir,
+            dryrun=True,
+            quiet=True,
+        )
+    except Exception as e:
+        raise REANAValidationError("Snakemake specification is invalid.") from e
     if not valid:
         raise REANAValidationError("Snakemake specification is invalid.")
 
@@ -96,7 +100,7 @@ def snakemake_validate_v8(
     """
     with SnakemakeApi(
         OutputSettings(
-            quiet=True,
+            quiet={Quietness.ALL},
         )
     ) as snakemake_api:
         try:
@@ -276,7 +280,7 @@ def snakemake_load_v7(workflow_file: str, **kwargs: Any):
                 "inputs": dict(rule._input),
                 "params": dict(rule._params),
                 "outputs": dict(rule._output),
-                "commands": [rule.shellcmd],
+                "commands": [rule.shellcmd] if rule.shellcmd else [],
                 "compute_backend": rule.resources.get("compute_backend"),
                 "kubernetes_memory_limit": rule.resources.get(
                     "kubernetes_memory_limit"
@@ -305,11 +309,44 @@ def snakemake_load_v8(workflow_file: str, **kwargs: Any):
     workflow_file = Path(workflow_file)  # convert str to Path
     configfiles = [Path(kwargs.get("input"))] if kwargs.get("input") else []
 
-    snakemake_validate(
-        workflow_file=workflow_file, configfiles=configfiles, workdir=workdir
-    )
+    def resource_value(rule, name):
+        """Return a concrete Snakemake resource value or None when unset."""
+        return rule.resources.get(name).value
+
+    with SnakemakeApi(OutputSettings(quiet={Quietness.ALL})) as snakemake_api:
+        try:
+            workflow_api = snakemake_api.workflow(
+                resource_settings=ResourceSettings(nodes=SNAKEMAKE_MAX_PARALLEL_JOBS),
+                config_settings=ConfigSettings(configfiles=configfiles),
+                storage_settings=StorageSettings(),
+                storage_provider_settings=dict(),
+                workflow_settings=WorkflowSettings(),
+                deployment_settings=DeploymentSettings(),
+                snakefile=workflow_file,
+                workdir=workdir,
+            )
+            workflow_api.dag()
+            rules = workflow_api._workflow.rules
+        except Exception as e:
+            raise REANAValidationError("Snakemake specification is invalid.") from e
 
     return {
         "job_dependencies": {},
-        "steps": [],
+        "steps": [
+            {
+                "name": rule.name,
+                "environment": (rule.container_img or "").replace("docker://", ""),
+                "inputs": dict(rule._input),
+                "params": dict(rule._params),
+                "outputs": dict(rule._output),
+                "commands": [rule.shellcmd] if rule.shellcmd else [],
+                "compute_backend": resource_value(rule, "compute_backend"),
+                "kubernetes_memory_limit": resource_value(
+                    rule, "kubernetes_memory_limit"
+                ),
+                "kubernetes_uid": resource_value(rule, "kubernetes_uid"),
+            }
+            for rule in rules
+            if not rule.norun
+        ],
     }

--- a/reana_commons/validation/images.py
+++ b/reana_commons/validation/images.py
@@ -10,6 +10,8 @@
 
 from typing import Dict, Iterator, List
 
+from reana_commons.config import REANA_DEFAULT_SNAKEMAKE_ENV_IMAGE
+
 
 def extract_images(reana_yaml: Dict) -> List[str]:
     """Extract container images from a REANA workflow specification.
@@ -23,9 +25,14 @@ def extract_images(reana_yaml: Dict) -> List[str]:
     :returns: List of image strings, one per step/requirement.
     """
     workflow_type = reana_yaml["workflow"]["type"]
-    specification = reana_yaml["workflow"].get("specification", {})
+    specification = reana_yaml["workflow"].get("specification") or {}
 
-    if workflow_type in ("serial", "snakemake"):
+    if workflow_type == "snakemake":
+        return [
+            step.get("environment") or REANA_DEFAULT_SNAKEMAKE_ENV_IMAGE
+            for step in specification.get("steps", [])
+        ]
+    elif workflow_type == "serial":
         return [step.get("environment", "") for step in specification.get("steps", [])]
     elif workflow_type == "yadage":
         return [

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -8,9 +8,8 @@
 
 """Tests for reana_commons.validation.images."""
 
-import pytest
-
-from reana_commons.validation.images import extract_cwl_images
+from reana_commons.config import REANA_DEFAULT_SNAKEMAKE_ENV_IMAGE
+from reana_commons.validation.images import extract_cwl_images, extract_images
 
 # ---------------------------------------------------------------------------
 # helpers
@@ -18,6 +17,42 @@ from reana_commons.validation.images import extract_cwl_images
 
 IMAGE = "docker.io/library/python:3.12"
 IMAGE2 = "docker.io/library/ubuntu:24.04"
+
+
+def test_snakemake_empty_environment_uses_default_image():
+    """Snakemake rules without containers resolve to the configured default."""
+    specification = {
+        "workflow": {
+            "type": "snakemake",
+            "specification": {"steps": [{"environment": ""}]},
+        }
+    }
+
+    assert extract_images(specification) == [REANA_DEFAULT_SNAKEMAKE_ENV_IMAGE]
+
+
+def test_serial_empty_environment_is_preserved():
+    """Default substitution must not affect other workflow engines."""
+    specification = {
+        "workflow": {
+            "type": "serial",
+            "specification": {"steps": [{"environment": ""}]},
+        }
+    }
+
+    assert extract_images(specification) == [""]
+
+
+def test_null_workflow_specification_has_no_extractable_images():
+    """Unexpanded workflow metadata must not crash server-side validation."""
+    specification = {
+        "workflow": {
+            "type": "yadage",
+            "specification": None,
+        }
+    }
+
+    assert extract_images(specification) == []
 
 
 def _wf(requirements=None, hints=None):

--- a/tests/test_snakemake.py
+++ b/tests/test_snakemake.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2021, 2022, 2023 CERN.
+# Copyright (C) 2021, 2022, 2023, 2024, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -9,17 +9,18 @@
 """REANA-Commons Snakemake tests."""
 
 import os
-import pytest
 import sys
 from pathlib import Path
 
+import pytest
+from reana_commons.errors import REANAValidationError
 from reana_commons.snakemake import snakemake_load
-
-
-@pytest.mark.xfail(
-    sys.version_info >= (3, 11),
-    reason="Test expected to fail for python versions 3.11 and above as we currently return only empty dictionary in snakemake_load function for python >= 3.11.",
+from reana_commons.validation.compute_backends import (
+    build_compute_backends_validator,
 )
+from reana_commons.validation.parameters import build_parameters_validator
+
+
 def test_snakemake_load(tmpdir, dummy_snakefile):
     """Test that Snakemake metadata is loaded properly."""
     workdir = tmpdir.mkdir("sub")
@@ -37,12 +38,97 @@ def test_snakemake_load(tmpdir, dummy_snakefile):
     # check that the cwd is preserved
     assert os.getcwd() == tmpdir
 
-    for step in metadata["steps"]:
-        assert step["kubernetes_memory_limit"] == "256Mi"
-
-    assert metadata["job_dependencies"] == {
-        "foo": [],
-        "bar": ["foo"],
-        "baz": ["foo", "bar"],
-        "all": ["foo", "bar", "baz"],
+    assert {step["name"]: step["environment"] for step in metadata["steps"]} == {
+        "foo": "docker.io/library/python:3.10.0-buster",
+        "bar": "docker.io/library/python:3.10.0-buster",
+        "baz": "docker.io/library/python:3.10.0-buster",
     }
+    assert all(step["commands"] for step in metadata["steps"])
+    assert all(step["kubernetes_memory_limit"] == "256Mi" for step in metadata["steps"])
+    assert all(step["compute_backend"] is None for step in metadata["steps"])
+
+    if sys.version_info < (3, 11):
+        for step in metadata["steps"]:
+            assert step["kubernetes_memory_limit"] == "256Mi"
+        assert metadata["job_dependencies"] == {
+            "foo": [],
+            "bar": ["foo"],
+            "baz": ["foo", "bar"],
+            "all": ["foo", "bar", "baz"],
+        }
+    else:
+        assert metadata["job_dependencies"] == {}
+
+    validator = build_parameters_validator(
+        {
+            "inputs": {"parameters": {}},
+            "workflow": {
+                "type": "snakemake",
+                "specification": metadata,
+            },
+        }
+    )
+    validator.validate_parameters()
+    build_compute_backends_validator(
+        {
+            "workflow": {
+                "type": "snakemake",
+                "specification": metadata,
+            },
+        },
+        ["kubernetes"],
+    ).validate()
+
+
+def test_snakemake_load_rule_without_container(tmpdir):
+    """Test that rules without a container preserve an empty environment."""
+    snakefile = tmpdir.join("Snakefile")
+    snakefile.write("""
+rule all:
+    input: "output.txt"
+    default_target: True
+
+rule create_output:
+    output: "output.txt"
+    resources:
+        compute_backend="kubernetes",
+        kubernetes_uid=1000
+    shell: "touch {output}"
+""")
+
+    metadata = snakemake_load(Path(snakefile.strpath))
+
+    assert len(metadata["steps"]) == 1
+    assert metadata["steps"][0]["name"] == "create_output"
+    assert metadata["steps"][0]["environment"] == ""
+    assert metadata["steps"][0]["commands"] == ["touch {output}"]
+    assert metadata["steps"][0]["compute_backend"] == "kubernetes"
+    assert metadata["steps"][0]["kubernetes_memory_limit"] is None
+    assert metadata["steps"][0]["kubernetes_uid"] == 1000
+
+
+def test_snakemake_load_rule_without_shell_command(tmpdir):
+    """Test that non-shell rules have no command metadata."""
+    snakefile = tmpdir.join("Snakefile")
+    snakefile.write("""
+rule create_output:
+    output: "output.txt"
+    run:
+        with open(output[0], "w"):
+            pass
+""")
+
+    metadata = snakemake_load(Path(snakefile.strpath))
+
+    assert len(metadata["steps"]) == 1
+    assert metadata["steps"][0]["name"] == "create_output"
+    assert metadata["steps"][0]["commands"] == []
+
+
+def test_snakemake_load_invalid_workflow(tmpdir):
+    """Test that parser failures are exposed as REANA validation errors."""
+    snakefile = tmpdir.join("Snakefile")
+    snakefile.write("this is not a valid Snakefile")
+
+    with pytest.raises(REANAValidationError, match="invalid"):
+        snakemake_load(Path(snakefile.strpath))


### PR DESCRIPTION
Populate Snakemake 8/9 workflow steps from parsed rules so container
image validation sees explicit images. Preserve the command, parameter,
resource, and input/output metadata required by downstream validation.

Normalise resource values and command metadata across supported
Snakemake versions. Convert parser failures to REANA validation errors
and tolerate omitted workflow metadata during server-side image checks.

Resolve rules without containers to the configured Snakemake default
during image extraction, requiring that default to be allowlisted. Use
the Snakemake 9 quietness setting consistently in both parser paths.

Closes reanahub/reana-workflow-engine-snakemake#129

