### PR TITLE
Add features for GPU, notification option and email address

### DIFF
--- a/reana_commons/api_client.py
+++ b/reana_commons/api_client.py
@@ -112,7 +112,10 @@ class JobControllerAPIClient(BaseAPIClient):
         slurm_time="",
         kubernetes_job_timeout: Optional[int] = None,
         c4p_cpu_cores="",
+        c4p_request_gpus="",
         c4p_memory_limit="",
+        c4p_notification="",
+        c4p_email_address="",
         c4p_additional_requirements="",
     ):
         """Submit a job to RJC API.
@@ -139,8 +142,11 @@ class JobControllerAPIClient(BaseAPIClient):
         :param slurm_time: Maximum timelimit of a Slurm job.
         :param kubernetes_job_timeout: Timeout for the job in seconds.
         :param c4p_cpu_cores: Amount of CPU cores requested to process C4P job
+        :param c4p_request_gpus: Amount of GPUs requested to process C4P job
         :param c4p_memory_limit: Amount of memory requested to process C4P job
-        :param c4p_additional_requirements: Additional requirements requested to process C4P job like GPU, etc.
+        :param c4p_notification: notification option to process C4P job
+        :param c4p_email_address: user email address to process C4P job
+        :param c4p_additional_requirements: Additional requirements requested to process C4P job like choice of a compute site
         :return: Returns a dict with the ``job_id``.
         """
         job_spec = {
@@ -202,8 +208,17 @@ class JobControllerAPIClient(BaseAPIClient):
         if c4p_cpu_cores:
             job_spec["c4p_cpu_cores"] = c4p_cpu_cores
 
+        if c4p_request_gpus:
+            job_spec["c4p_request_gpus"] = c4p_request_gpus
+
         if c4p_memory_limit:
             job_spec["c4p_memory_limit"] = c4p_memory_limit
+
+        if c4p_notification:
+            job_spec["c4p_notification"] = c4p_notification
+
+        if c4p_email_address:
+            job_spec["c4p_email_address"] = c4p_email_address
 
         if c4p_additional_requirements:
             job_spec["c4p_additional_requirements"] = c4p_additional_requirements

--- a/reana_commons/openapi_specifications/reana_job_controller.json
+++ b/reana_commons/openapi_specifications/reana_job_controller.json
@@ -45,7 +45,19 @@
         "c4p_cpu_cores": {
           "type": "string"
         },
+        "c4p_request_gpus": {
+          "default": "",
+          "type": "string"
+        },
         "c4p_memory_limit": {
+          "type": "string"
+        },
+        "c4p_notification": {
+          "default": "",
+          "type": "string"
+        },
+        "c4p_email_address": {
+          "default": "",
           "type": "string"
         },
         "cmd": {

--- a/reana_commons/serial.py
+++ b/reana_commons/serial.py
@@ -108,8 +108,23 @@ serial_workflow_schema = {
                         "type": "string",
                         "default": "",
                     },
+                    "c4p_request_gpus": {
+                        "$id": "#/properties/steps/properties/c4p_request_gpus",
+                        "type": "string",
+                        "default": "",
+                    },
                     "c4p_memory_limit": {
                         "$id": "#/properties/steps/properties/c4p_memory_limit",
+                        "type": "string",
+                        "default": "",
+                    },
+                    "c4p_notification": {
+                        "$id": "#/properties/steps/properties/c4p_notification",
+                        "type": "string",
+                        "default": "",
+                    },
+                    "c4p_email_address": {
+                        "$id": "#/properties/steps/properties/c4p_email_address",
                         "type": "string",
                         "default": "",
                     },

--- a/reana_commons/validation/schemas/reana_analysis_schema.json
+++ b/reana_commons/validation/schemas/reana_analysis_schema.json
@@ -319,15 +319,30 @@
                       "title": "C4P CPU Cores",
                       "description": "Number of CPU cores requested from Compute4PUNCH for running the task."
                     },
+                    "c4p_request_gpus": {
+                      "type": "string",
+                      "title": "C4P Requested GPUs",
+                      "description": "Number of GPUs requested from Compute4PUNCH for running the task."
+                    },
                     "c4p_memory_limit": {
                       "type": "string",
                       "title": "C4P Memory Limit",
                       "description": "Amount of memory requested from Compute4PUNCH for running the task."
                     },
+                    "c4p_notification": {
+                      "type": "string",
+                      "title": "C4P Notification",
+                      "description": "Notification option used when running the task on Compute4PUNCH."
+                    },
+                    "c4p_email_address": {
+                      "type": "string",
+                      "title": "C4P Email Address",
+                      "description": "User email address used when running the task on Compute4PUNCH."
+                    },
                     "c4p_additional_requirements": {
                       "type": "string",
                       "title": "C4P Additional Requirements",
-                      "description": "Additional HTCondor requirements like RequestGPUs for running the task."
+                      "description": "Additional HTCondor requirements - like choice of a compute site - for running the task."
                     }
                   },
                   "required": [


### PR DESCRIPTION
Dear Tibor, dear all,

The following optional parameters have been added for the Compute4PUNCH backend:

C4P_REQUEST_GPUS: Number of GPUs used to run the REANA jobs.
C4P_NOTIFICATION: Notification option used by the REANA jobs.
C4P_EMAIL_ADDRESS: User email address used by the REANA jobs.

Their purposes are the following:

C4P_REQUEST_GPUS: access to the GPUs of the Compute4PUNCH infrastructure.
C4P_NOTIFICATION: notification option in HTCondor (Always | Complete | Start | Error | Never).
C4P_EMAIL_ADDRESS: user email, to be notified about the job status and about the remaining life time of the Mytoken used to periodically renew the access token (required to access the Storage4PUNCH infrastructure).

Thanks a lot in advance for your feedback!

Best wishes,
Benoit Roland