### PR TITLE
fix(testing): purge in-memory queue between tests

### DIFF
--- a/reana_commons/testing/fixtures.py
+++ b/reana_commons/testing/fixtures.py
@@ -25,6 +25,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 from kombu import Connection, Exchange, Queue
+from kombu.transport import memory
 
 from reana_commons.consumer import BaseConsumer
 
@@ -527,14 +528,14 @@ def consume_queue():
     return _consume_queue
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def in_memory_queue_connection():
     """In memory message queue.
 
-    Scope: session
+    Scope: function
 
-    This fixture offers an in memory class:`kombu.Connection` scoped to the
-    testing session.
+    This fixture offers an in memory class:`kombu.Connection` scoped to a
+    single test.
 
     .. code-block:: python
 
@@ -544,7 +545,14 @@ def in_memory_queue_connection():
 
 
     """
-    return Connection("memory:///")
+    connection = Connection("memory:///")
+    yield connection
+    connection.release()
+    # Kombu stores the queues of the ``memory://`` transport in a class
+    # attribute, so a new connection alone does not give a new set of queues.
+    # Empty them here, otherwise messages left behind by one test are still
+    # waiting in the queue when the next test runs.
+    memory.Channel.queues.clear()
 
 
 @pytest.fixture

--- a/tests/test_mq.py
+++ b/tests/test_mq.py
@@ -35,6 +35,21 @@ def test_consume_msg(
     consumer.on_message.assert_called_once_with({"hello": "REANA"}, ANY)
 
 
+def test_leave_stray_message_in_queue(default_in_memory_producer, default_queue):
+    """Publish a message and leave it in the queue on purpose.
+
+    This test pairs with ``test_queue_starts_empty``, which must not see the
+    message published here. The two tests have to stay in this order.
+    """
+    default_in_memory_producer.publish({"stray": "message"}, declare=[default_queue])
+
+
+def test_queue_starts_empty(in_memory_queue_connection, default_queue):
+    """Test that messages do not leak from one test to the next."""
+    bound_queue = default_queue(in_memory_queue_connection.channel())
+    assert bound_queue.queue_declare(passive=False).message_count == 0
+
+
 def test_server_unreachable(ConsumerBase, default_queue):
     """Test consumer never starts because server is unreachable."""
     unreachable_connection = Connection("amqp://unreachable:5672")


### PR DESCRIPTION
The `in_memory_queue_connection` fixture was session scoped, so messages left behind by one test were still in the queue for the next one.

Function scope alone does not fix this: kombu keeps the queues of the memory transport in a class attribute, so a fresh connection shares them. Empty them on teardown too.

Closes reanahub/reana-commons#528