### PR TITLE
fix(testing): isolate in-memory queues between tests

### DIFF
--- a/reana_commons/testing/fixtures.py
+++ b/reana_commons/testing/fixtures.py
@@ -527,14 +527,14 @@ def consume_queue():
     return _consume_queue
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def in_memory_queue_connection():
     """In memory message queue.
 
-    Scope: session
+    Scope: function
 
     This fixture offers an in memory class:`kombu.Connection` scoped to the
-    testing session.
+    current test.
 
     .. code-block:: python
 
@@ -544,7 +544,14 @@ def in_memory_queue_connection():
 
 
     """
-    return Connection("memory:///")
+    connection = Connection("memory:///")
+    transport = connection.transport
+    try:
+        yield connection
+    finally:
+        connection.release()
+        transport.Channel.queues.clear()
+        transport.state.clear()
 
 
 @pytest.fixture

--- a/tests/test_mq.py
+++ b/tests/test_mq.py
@@ -10,6 +10,7 @@
 
 import json
 import threading
+from queue import Empty
 
 import pytest
 from kombu import Connection, Exchange, Queue
@@ -33,6 +34,21 @@ def test_consume_msg(
     default_in_memory_producer.publish({"hello": "REANA"}, declare=[default_queue])
     consume_queue(consumer, limit=1)
     consumer.on_message.assert_called_once_with({"hello": "REANA"}, ANY)
+
+
+def test_in_memory_queue_connection_leaves_message_for_teardown(
+    in_memory_queue_connection,
+):
+    """Leave a message behind to exercise the fixture teardown."""
+    queue = in_memory_queue_connection.SimpleQueue("test-fixture-isolation")
+    queue.put({"hello": "previous test"})
+
+
+def test_in_memory_queue_connection_starts_empty(in_memory_queue_connection):
+    """Test messages from a previous test do not leak into this one."""
+    queue = in_memory_queue_connection.SimpleQueue("test-fixture-isolation")
+    with pytest.raises(Empty):
+        queue.get(block=False)
 
 
 def test_server_unreachable(ConsumerBase, default_queue):


### PR DESCRIPTION
## Summary

- make the in-memory queue connection fixture function-scoped
- clear shared queues and broker routing state during teardown
- add regression coverage for messages leaking across tests

## Testing

- `tests/test_mq.py`: 5 passed

Closes #528